### PR TITLE
asyncssh: fix api change: make kwargs to posargs

### DIFF
--- a/sshfs/config.py
+++ b/sshfs/config.py
@@ -17,12 +17,15 @@ def parse_config(
         with suppress(KeyError):
             local_user = getpass.getuser()
 
+    last_config = None
+    reload = False
+
     return SSHClientConfig.load(
-        reload=False,
-        last_config=None,
-        config_paths=config_files,
-        local_user=local_user,
-        user=user,
-        host=host,
-        port=port,
+        last_config,
+        config_files,
+        reload,
+        local_user,
+        user,
+        host,
+        port,
     )


### PR DESCRIPTION
In `asyncssh==2.9`, the API in [`SSHClientConfig.load`](https://github.com/ronf/asyncssh/blob/6c7d6466fb15468bae0ae7b8684f70989651fc75/asyncssh/config.py#L361-L363) was changed from accepting `kwargs` to only positional args and requires arguments to be passed in order of:
```
last_config, config_paths, reload, local_user, user, host, port
```

This should support all `asyncssh` versions supported including `2.9`.