### PR TITLE
Register SSHFileSystem with fsspec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,20 @@ the SFTP protocol using [asyncssh](https://github.com/ronf/asyncssh).
 
 ## Tutorial
 
-Install the `sshfs` from PyPI or the conda-forge, and import it;
+Install the `sshfs` from PyPI or the conda-forge. This will install `fsspec`
+and register `sshfs` for `ssh://` urls, so you can open files using:
+
+```py
+from fsspec import open
+
+with open('ssh://[user@]host[:port]/path/to/file', "w") as file:
+    file.write("Hello World!")
+
+with open('ssh://[user@]host[:port]/path/to/file', "r") as file:
+    print(file.read())
+```
+
+For more operations, you can use the `SSHFileSystem` class directly:
 
 ```py
 from sshfs import SSHFileSystem
@@ -43,6 +56,8 @@ fs = SSHFileSystem(
 )
 ```
 
+Note: you can also pass `client_keys` as an argument to `fsspec.open`.
+
 All operations and their descriptions are specified [here](https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem).
 Here are a few example calls you can make, starting with `info()` which allows you to retrieve the metadata about given path;
 
@@ -61,7 +76,7 @@ You can also create new files through either putting a local file with `put_file
 ```py
 >>> with fs.open('/tmp/message.dat', 'wb') as stream:
 ...     stream.write(b'super secret messsage!')
-... 
+...
 ```
 
 And either download it through `get_file` or simply read it on the fly with opening it;
@@ -69,7 +84,7 @@ And either download it through `get_file` or simply read it on the fly with open
 ```py
 >>> with fs.open('/tmp/message.dat') as stream:
 ...     print(stream.read())
-... 
+...
 b'super secret messsage!'
 ```
 
@@ -80,10 +95,10 @@ There are also a lot of other basic filesystem operations, such as `mkdir`, `tou
 >>> fs.mkdir('/tmp/dir/eggs')
 >>> fs.touch('/tmp/dir/spam')
 >>> fs.touch('/tmp/dir/eggs/quux')
->>> 
+>>>
 >>> for file in fs.find('/tmp/dir'):
 ...     print(file)
-... 
+...
 /tmp/dir/eggs/quux
 /tmp/dir/spam
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,3 +26,7 @@ libnacl = asyncssh[libnacl]
 pkcs11 = asyncssh[python-pkcs11]
 pyopenssl = asyncssh[pyOpenSSL]
 pywin32 = asyncssh[pywin32]
+
+[options.entry_points]
+fsspec.specs =
+    ssh = sshfs.spec:SSHFileSystem

--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -76,7 +76,9 @@ class SSHFileSystem(AsyncFileSystem):
 
     @classmethod
     def _strip_protocol(cls, path):
-        return infer_storage_options(path)["path"]
+        # Remove components such as host and username from path.
+        inferred_path = infer_storage_options(path)["path"]
+        return super()._strip_protocol(inferred_path)
 
     @staticmethod
     def _get_kwargs_from_urls(urlpath):

--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -9,6 +9,7 @@ from datetime import datetime
 import asyncssh
 from asyncssh.sftp import SFTPOpUnsupported
 from fsspec.asyn import AsyncFileSystem, async_methods, sync, sync_wrapper
+from fsspec.utils import infer_storage_options
 
 from sshfs.file import SSHFile
 from sshfs.pools import SFTPSoftChannelPool
@@ -72,6 +73,17 @@ class SSHFileSystem(AsyncFileSystem):
         weakref.finalize(
             self, sync, self.loop, self._finalize, self._pool, self._stack
         )
+
+    @classmethod
+    def _strip_protocol(cls, path):
+        return infer_storage_options(path)["path"]
+
+    @staticmethod
+    def _get_kwargs_from_urls(urlpath):
+        out = infer_storage_options(urlpath)
+        out.pop("path", None)
+        out.pop("protocol", None)
+        return out
 
     @wrap_exceptions
     async def _connect(

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -83,10 +83,10 @@ def test_fsspec_registration(fs, ssh_server, remote_dir, user="user"):
         file_fs = file.buffer.fs
         assert isinstance(file_fs, SSHFileSystem)
         assert file_fs.storage_options == {
-            'host': ssh_server.host,
-            'port': ssh_server.port,
-            'username': user,
-            'client_keys': [USERS[user]],
+            "host": ssh_server.host,
+            "port": ssh_server.port,
+            "username": user,
+            "client_keys": [USERS[user]],
         }
         # Write something.
         file.write("Anything")

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -84,8 +84,7 @@ def test_fsspec_registration(ssh_server):
 
 
 def test_fsspec_url_parsing(ssh_server, remote_dir, user="user"):
-    path = remote_dir + "/a.txt"
-    url = f"ssh://{user}@{ssh_server.host}:{ssh_server.port}/{path}"
+    url = f"ssh://{user}@{ssh_server.host}:{ssh_server.port}/{remote_dir}/file"
     with fsspec.open(url, "w", client_keys=[USERS[user]]) as file:
         # Check the underlying file system.
         file_fs = file.buffer.fs

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -6,8 +6,8 @@ import warnings
 from concurrent import futures
 from datetime import datetime, timedelta
 from pathlib import Path
-import fsspec
 
+import fsspec
 import pytest
 from asyncssh.sftp import SFTPFailure
 

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -79,6 +79,16 @@ def test_fsspec_registration(fs, ssh_server, remote_dir, user="user"):
     # Additional options like client_keys need to be passed to open.
     url = f"ssh://{user}@{ssh_server.host}:{ssh_server.port}/{path}"
     with fsspec.open(url, "w", client_keys=[USERS[user]]) as file:
+        # Check the underlying file system.
+        file_fs = file.buffer.fs
+        assert isinstance(file_fs, SSHFileSystem)
+        assert file_fs.storage_options == {
+            'host': ssh_server.host,
+            'port': ssh_server.port,
+            'username': user,
+            'client_keys': [USERS[user]],
+        }
+        # Write something.
         file.write("Anything")
 
     with fs.open(path, "r") as file:


### PR DESCRIPTION
Related to #25.

Currently, it is not possible to register the SSHFileSystem with fsspec.

However, it seems to me that the only thing that is missing is appropriate parsing of the protocol string.
I compared the current SSHFileSystem with the [AbstractFileSystem](https://github.com/fsspec/filesystem_spec/blob/a85876a6f8a0751adccbeed9defc12e8e69f59f9/fsspec/spec.py#L95) base class and discovered that only two methods are missing: `_strip_protocol`, which removes all protocol info from a url, and `_get_kwargs_from_urls`, which translates a URL to the appropriate arguments to instantiate the class.

I leveraged the fact that sshfs is already able to parse ssh URLs, and copied the required functions from the existing [STFP filesystem](https://github.com/fsspec/filesystem_spec/blob/a85876a6f8a0751adccbeed9defc12e8e69f59f9/fsspec/implementations/sftp.py#L57-L66).

Finally, I updated `setup.cfg` such that the SSHFileSystem is automatically registered for the `ssh` protocol when installing this library.

Testing locally with my setup, this works like a charm. However, I would like to contribute towards testing this more thoroughly. I would appreciate any pointers on how to achieve this most efficiently. Thanks!