### PR TITLE
SSHFileSystem._info should strip the protocol from the path

### DIFF
--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -137,6 +137,7 @@ class SSHFileSystem(AsyncFileSystem):
 
     @wrap_exceptions
     async def _info(self, path, **kwargs):
+        path = self._strip_protocol(path)
         async with self._pool.get() as channel:
             attributes = await channel.stat(path)
 


### PR DESCRIPTION
This is based on some pain points i was having while using GenericFileSystem.
Looks like other FS implementations also strip first. Seems like a "safe" thing to do.

`pytest` passes... for what it's worth.