### PR TITLE
Support for fs.modified

### DIFF
--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -148,6 +148,13 @@ class SSHFileSystem(AsyncFileSystem):
         return info
 
     @wrap_exceptions
+    async def _modified(self, path: str, **kwargs) -> datetime:
+        path_info = await self._info(path)
+        return path_info["mtime"]
+
+    modified = sync_wrapper(_modified)
+
+    @wrap_exceptions
     async def _mv(self, lpath, rpath, **kwargs):
         async with self._pool.get() as channel:
             with suppress(SFTPOpUnsupported):

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -4,6 +4,7 @@ import secrets
 import tempfile
 import warnings
 from concurrent import futures
+from datetime import datetime
 from pathlib import Path
 
 import fsspec
@@ -337,3 +338,8 @@ def test_concurrency_for_raw_commands(fs, remote_dir):
         ]
         for future in futures.as_completed(cp_futures):
             future.result()
+
+
+def test_modified(fs, remote_dir):
+    modified = fs.modified(remote_dir)
+    assert isinstance(modified, datetime)


### PR DESCRIPTION
Currently, calling `fs.modified(filepath)` throws a `NotImplementedError`. It's a really quick add since this information is already available from `fs.info(filepath)`.

This PR adds in `modified` and `_modified` as methods to the filesystem as a convenience.

Note: I've added a test that I *think* should work, but I can't actually get my environment setup to correctly run the test suite (I couldn't find a contributor guide but appologies if I missed something obvious). When I try to run the tests in python 3.10 I get a very strange error on importing paramiko because it uses `asnyc` as a keyword argument somewhere under the hood which is forbidden.