### PR TITLE
Add _cat_file

### DIFF
--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -319,10 +319,9 @@ class SSHFileSystem(AsyncFileSystem):
 
     @wrap_exceptions
     async def _cat_file(self, path, **kwargs):
-        """ Asynchronously fetch the contents of a file """
+        """Asynchronously fetch the contents of a file"""
         async with self._pool.get() as channel:
-            async with channel.open(path, 'rb') as f:
+            async with channel.open(path, "rb") as f:
                 return await f.read()
 
     cat_file = sync_wrapper(_cat_file)
-

--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -323,5 +323,3 @@ class SSHFileSystem(AsyncFileSystem):
         async with self._pool.get() as channel:
             async with channel.open(path, "rb") as f:
                 return await f.read()
-
-    cat_file = sync_wrapper(_cat_file)

--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -316,3 +316,13 @@ class SSHFileSystem(AsyncFileSystem):
 
     def _open(self, path, *args, **kwargs):
         return SSHFile(self, path, *args, **kwargs)
+
+    @wrap_exceptions
+    async def _cat_file(self, path, **kwargs):
+        """ Asynchronously fetch the contents of a file """
+        async with self._pool.get() as channel:
+            async with channel.open(path, 'rb') as f:
+                return await f.read()
+
+    cat_file = sync_wrapper(_cat_file)
+

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -345,9 +345,8 @@ def test_cat_file_sync(fs, remote_dir):
     test_file_path = remote_dir + "/test_file.txt"
 
     # Write content to the file synchronously
-    with fs._pool.get() as channel:
-        with channel.open(test_file_path, 'wb') as f:
-            f.write(test_content)
+    with open(test_file_path, 'wb') as f:
+        f.write(test_content)
 
     # Use the cat_file method to read the content back synchronously
     read_content = fs.cat_file(test_file_path)

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -337,3 +337,21 @@ def test_concurrency_for_raw_commands(fs, remote_dir):
         ]
         for future in futures.as_completed(cp_futures):
             future.result()
+
+
+@pytest.mark.asyncio
+async def test_cat_file(fs, remote_dir):
+    # Define the content to write to the test file
+    test_content = b'Test content for _cat_file'
+    test_file_path = remote_dir + "/test_file.txt"
+
+    # Write content to the file asynchronously
+    async with fs._pool.get() as channel:
+        async with channel.open(test_file_path, 'wb') as f:
+            await f.write(test_content)
+
+    # Use the _cat_file method to read the content back
+    read_content = await fs._cat_file(test_file_path)
+
+    # Verify the content read is the same as the content written
+    assert read_content == test_content, "The content read from the file does not match the content written."

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -341,15 +341,17 @@ def test_concurrency_for_raw_commands(fs, remote_dir):
 
 def test_cat_file_sync(fs, remote_dir):
     # Define the content to write to the test file
-    test_content = b'Test content for cat_file'
+    test_content = b"Test content for cat_file"
     test_file_path = remote_dir + "/test_file.txt"
 
     # Write content to the file synchronously
-    with open(test_file_path, 'wb') as f:
+    with open(test_file_path, "wb") as f:
         f.write(test_content)
 
     # Use the cat_file method to read the content back synchronously
     read_content = fs.cat_file(test_file_path)
 
     # Verify the content read is the same as the content written
-    assert read_content == test_content, "The content read from the file does not match the content written."
+    assert (
+        read_content == test_content
+    ), "The content read from the file does not match the content written."

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -339,19 +339,18 @@ def test_concurrency_for_raw_commands(fs, remote_dir):
             future.result()
 
 
-@pytest.mark.asyncio
-async def test_cat_file(fs, remote_dir):
+def test_cat_file_sync(fs, remote_dir):
     # Define the content to write to the test file
-    test_content = b'Test content for _cat_file'
+    test_content = b'Test content for cat_file'
     test_file_path = remote_dir + "/test_file.txt"
 
-    # Write content to the file asynchronously
-    async with fs._pool.get() as channel:
-        async with channel.open(test_file_path, 'wb') as f:
-            await f.write(test_content)
+    # Write content to the file synchronously
+    with fs._pool.get() as channel:
+        with channel.open(test_file_path, 'wb') as f:
+            f.write(test_content)
 
-    # Use the _cat_file method to read the content back
-    read_content = await fs._cat_file(test_file_path)
+    # Use the cat_file method to read the content back synchronously
+    read_content = fs.cat_file(test_file_path)
 
     # Verify the content read is the same as the content written
     assert read_content == test_content, "The content read from the file does not match the content written."


### PR DESCRIPTION
Howdy folks, sshfs is amazing. Thank you for everything!

I was trying to use it for remote visualization of [zarr](https://zarr.readthedocs.io/en/stable/) images. This required support for `_cat_file`. This PR provides a `_cat_file` implementation.