### PR TITLE
Add _pipe_file and test

### DIFF
--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -338,9 +338,9 @@ class SSHFileSystem(AsyncFileSystem):
         await self._makedirs(self._parent(path), exist_ok=True)
 
         async with self._pool.get() as channel:
-            async with channel.open(path, 'wb') as f:
+            async with channel.open(path, "wb") as f:
                 for i in range(0, len(data), chunksize):
-                    chunk = data[i:i + chunksize]
+                    chunk = data[i : i + chunksize]
                     await f.write(chunk)
                     await f.flush()
 

--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -342,6 +342,5 @@ class SSHFileSystem(AsyncFileSystem):
                 for i in range(0, len(data), chunksize):
                     chunk = data[i : i + chunksize]
                     await f.write(chunk)
-                    await f.flush()
 
         self.invalidate_cache(path)

--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -336,7 +336,7 @@ class SSHFileSystem(AsyncFileSystem):
     async def _pipe_file(self, path, data, chunksize=50 * 2**20, **kwargs):
         """Asynchronously writes the given data to a remote file in chunks."""
         await self._makedirs(self._parent(path), exist_ok=True)
-        
+
         async with self._pool.get() as channel:
             async with channel.open(path, 'wb') as f:
                 for i in range(0, len(data), chunksize):
@@ -346,4 +346,3 @@ class SSHFileSystem(AsyncFileSystem):
 
         self.invalidate_cache(path)
 
-    pipe_file = sync_wrapper(_pipe_file)

--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -331,3 +331,19 @@ class SSHFileSystem(AsyncFileSystem):
         async with self._pool.get() as channel:
             async with channel.open(path, "rb") as f:
                 return await f.read()
+
+    @wrap_exceptions
+    async def _pipe_file(self, path, data, chunksize=50 * 2**20, **kwargs):
+        """Asynchronously writes the given data to a remote file in chunks."""
+        await self._makedirs(self._parent(path), exist_ok=True)
+        
+        async with self._pool.get() as channel:
+            async with channel.open(path, 'wb') as f:
+                for i in range(0, len(data), chunksize):
+                    chunk = data[i:i + chunksize]
+                    await f.write(chunk)
+                    await f.flush()
+
+        self.invalidate_cache(path)
+
+    pipe_file = sync_wrapper(_pipe_file)

--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -149,6 +149,13 @@ class SSHFileSystem(AsyncFileSystem):
         return info
 
     @wrap_exceptions
+    async def _modified(self, path: str, **kwargs) -> datetime:
+        path_info = await self._info(path)
+        return path_info["mtime"]
+
+    modified = sync_wrapper(_modified)
+
+    @wrap_exceptions
     async def _mv(self, lpath, rpath, **kwargs):
         async with self._pool.get() as channel:
             with suppress(SFTPOpUnsupported):

--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -345,4 +345,3 @@ class SSHFileSystem(AsyncFileSystem):
                     await f.flush()
 
         self.invalidate_cache(path)
-

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -4,6 +4,7 @@ import secrets
 import tempfile
 import warnings
 from concurrent import futures
+from datetime import datetime
 from pathlib import Path
 
 import fsspec
@@ -337,6 +338,11 @@ def test_concurrency_for_raw_commands(fs, remote_dir):
         ]
         for future in futures.as_completed(cp_futures):
             future.result()
+
+
+def test_modified(fs, remote_dir):
+    modified = fs.modified(remote_dir)
+    assert isinstance(modified, datetime)
 
 
 def test_cat_file_sync(fs, remote_dir):

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -87,7 +87,9 @@ def test_fsspec_registration(ssh_server):
 
 def test_fsspec_url_parsing(ssh_server, remote_dir, user="user"):
     for ep in pkg_resources.iter_entry_points(group="fsspec.specs"):
-        url = f"{ep.name}://{user}@{ssh_server.host}:{ssh_server.port}/{remote_dir}/file"
+        url = (
+            f"{ep.name}://{user}@{ssh_server.host}:{ssh_server.port}/{remote_dir}/file"
+        )
         with fsspec.open(url, "w", client_keys=[USERS[user]]) as file:
             # Check the underlying file system.
             file_fs = file.buffer.fs
@@ -296,7 +298,6 @@ def test_concurrent_operations(fs, remote_dir):
             return stream.read()
 
     with futures.ThreadPoolExecutor() as executor:
-
         write_futures, _ = futures.wait(
             [executor.submit(create_random_file) for _ in range(64)],
             return_when=futures.ALL_COMPLETED,
@@ -370,4 +371,6 @@ def test_pipe_file(fs, remote_dir):
     fs.pipe_file(test_file_path, test_data)
 
     with fs.open(test_file_path, "rb") as f:
-        assert f.read() == test_data, "The data read from the file does not match the data written."
+        assert (
+            f.read() == test_data
+        ), "The data read from the file does not match the data written."

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -87,9 +87,7 @@ def test_fsspec_registration(ssh_server):
 
 def test_fsspec_url_parsing(ssh_server, remote_dir, user="user"):
     for ep in pkg_resources.iter_entry_points(group="fsspec.specs"):
-        url = (
-            f"{ep.name}://{user}@{ssh_server.host}:{ssh_server.port}/{remote_dir}/file"
-        )
+        url = f"{ep.name}://{user}@{ssh_server.host}:{ssh_server.port}/{remote_dir}/file"
         with fsspec.open(url, "w", client_keys=[USERS[user]]) as file:
             # Check the underlying file system.
             file_fs = file.buffer.fs

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -361,3 +361,13 @@ def test_cat_file_sync(fs, remote_dir):
     assert (
         read_content == test_content
     ), "The content read from the file does not match the content written."
+
+
+def test_pipe_file(fs, remote_dir):
+    test_data = b"Test data for pipe_file" * (2**20)  # 1 MB of test data
+    test_file_path = remote_dir + "/test_pipe_file.txt"
+
+    fs.pipe_file(test_file_path, test_data)
+
+    with fs.open(test_file_path, "rb") as f:
+        assert f.read() == test_data, "The data read from the file does not match the data written."


### PR DESCRIPTION
@uermel found that we also need `_pipe_file` to write zarr files using sshfs when implementing tests for [copick](https://github.com/uermel/copick) (which leverages fsspec). 

This PR adds `_pipe_file` and a corresponding test.