### PR TITLE
Implement io.IOBase.seekable method

### DIFF
--- a/sshfs/file.py
+++ b/sshfs/file.py
@@ -81,6 +81,9 @@ class SSHFile(io.IOBase):
     def readable(self):
         return "r" in self.mode
 
+    def seekable(self):
+        return True
+
     def writable(self):
         return not self.readable()
 


### PR DESCRIPTION
`SSHFile` inherits from `io.IOBase`, but even though `seek` can be called on it, the `seekable` method is not overwritten and therefore returns False via the [default implementation in `io.IOBase`](https://github.com/python/cpython/blob/29951c8471f4b4283493c8e3f768d967d0bdd564/Lib/_pyio.py#L421C1-L421C21).