### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ on: push
 name: Publish
 
 jobs:
-  pulish:
+  publish:
     runs-on: ubuntu-latest
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,6 @@ repos:
         - mdformat-black
         - mdformat_tables
 - repo: https://github.com/codespell-project/codespell
-  # Configuration for codespell is in pyproject.toml
   rev: v2.3.0
   hooks:
   - id: codespell

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,10 @@ repos:
         additional_dependencies:
         - mdformat-black
         - mdformat_tables
+- repo: https://github.com/codespell-project/codespell
+  # Configuration for codespell is in pyproject.toml
+  rev: v2.3.0
+  hooks:
+  - id: codespell
+    additional_dependencies:
+    - tomli

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ You can also create new files through either putting a local file with `put_file
 
 ```py
 >>> with fs.open('/tmp/message.dat', 'wb') as stream:
-...     stream.write(b'super secret messsage!')
+...     stream.write(b'super secret message!')
 ...
 ```
 
@@ -85,7 +85,7 @@ And either download it through `get_file` or simply read it on the fly with open
 >>> with fs.open('/tmp/message.dat') as stream:
 ...     print(stream.read())
 ...
-b'super secret messsage!'
+b'super secret message!'
 ```
 
 There are also a lot of other basic filesystem operations, such as `mkdir`, `touch` and `find`;

--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -105,7 +105,7 @@ class SSHFileSystem(AsyncFileSystem):
 
         # If an error occurs while the SSHFile is trying to
         # open the native file, then the client might get broken
-        # due to partial initalization. We are just going to ignore
+        # due to partial initialization. We are just going to ignore
         # the errors that arises on the finalization layer
         with suppress(BrokenPipeError):
             await stack.aclose()


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.