### PR TITLE
fix parse_config for asyncssh>=2.19.0

### DIFF
--- a/sshfs/config.py
+++ b/sshfs/config.py
@@ -1,7 +1,9 @@
 import getpass
+import warnings
 from contextlib import suppress
 from pathlib import Path
 
+import asyncssh
 from asyncssh.config import SSHClientConfig
 
 SSH_CONFIG = Path("~", ".ssh", "config").expanduser()
@@ -10,20 +12,40 @@ SSH_CONFIG = Path("~", ".ssh", "config").expanduser()
 def parse_config(
     *, host, user=(), port=(), local_user=None, config_files=None
 ):
+    warnings.warn(
+        "parse_config is deprecated and will be removed in the future.",
+        DeprecationWarning,
+    )
+
     if config_files is None:
         config_files = [SSH_CONFIG]
 
     if local_user is None:
-        with suppress(KeyError):
+        with suppress(KeyError, OSError):
             local_user = getpass.getuser()
 
     last_config = None
     reload = False
 
+    version = tuple(map(int, asyncssh.__version__.split(".")))
+    if version < (2, 19, 0):
+        return SSHClientConfig.load(
+            last_config,
+            config_files,
+            reload,
+            local_user,
+            user,
+            host,
+            port,
+        )
+    canonical = False
+    final = False
     return SSHClientConfig.load(
         last_config,
         config_files,
         reload,
+        canonical,
+        final,
         local_user,
         user,
         host,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -45,7 +45,4 @@ def test_config_expansions(tmpdir):
         ProxyCommand ssh proxy nc %h %p
     """,
     )
-
-    assert (
-        config.get("ProxyCommand") == "ssh proxy nc base.dvc.org 222".split()
-    )
+    assert config.get("ProxyCommand") == "ssh proxy nc base.dvc.org 222"


### PR DESCRIPTION
Also deprecate the function and raise a warning when it is used.

Supersedes and closes #57.