### PR TITLE
Set cachable to false

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,6 @@ force_grid_wrap=0
 include_trailing_comma=true
 multi_line_output=3
 use_parentheses=true
+
+[tool.codespell]
+ignore-words-list=cachable

--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -63,6 +63,7 @@ class SSHFileSystem(AsyncFileSystem):
         _client_args.setdefault("known_hosts", None)
 
         self._stack = AsyncExitStack()
+        self.cachable = False
         self.active_executors = 0
         self._client, self._pool = self.connect(
             host,


### PR DESCRIPTION
Closes issue #42

At the moment, because SSHFS is considered `cachable`, creating a new filesystem *doesn't* create a new connection, and maintains the old one.

That's probably not a good fit for SFTP connections, since they're likely to timeout and be closed off after a while, so almost any long running process using SSHFS is eventually going to hit an issue where the filesystem continues to reference a closed off connection, and the cache needs to be manually cleared.

To fix that, I've just set "cachable" to False here, so that creating a new filesystem would also bring in a new connection.

Honestly, I don't have the knowledge to know the full implications of this, but my main thoughts are:
- Does this mean it's worth adding in something to clean up / close the connection when the SSHFS object goes out of memory? (otherwise there are potentially open but unusable connections floating around)
- Is there a case where you'd want it to be cachable? In which case, the "cachable" setting could theoretically be put behind an `__init__` argument? (my guess is that'd cause some kind of side effects nobody is expecting though)