### PR TITLE
fix: preserve absolute root in _strip_protocol so walk("/") works

### DIFF
--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -35,6 +35,8 @@ _DEFAULT_MAX_SESSIONS = 10
 
 
 class SSHFileSystem(AsyncFileSystem):
+    root_marker = "/"
+
     def __init__(
         self,
         host,

--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -35,8 +35,6 @@ _DEFAULT_MAX_SESSIONS = 10
 
 
 class SSHFileSystem(AsyncFileSystem):
-    root_marker = "/"
-
     def __init__(
         self,
         host,
@@ -86,7 +84,14 @@ class SSHFileSystem(AsyncFileSystem):
     def _strip_protocol(cls, path):
         # Remove components such as host and username from path.
         inferred_path = infer_storage_options(path)["path"]
-        return super()._strip_protocol(inferred_path)
+        stripped = super()._strip_protocol(inferred_path)
+        # super() collapses a bare "/" to the (empty) root_marker. Restore it
+        # only when the caller explicitly supplied the absolute root, so that
+        # walk("/") lists from the root while relative paths (and "") still
+        # resolve against the home directory.
+        if not stripped and inferred_path.startswith("/"):
+            return "/"
+        return stripped
 
     @staticmethod
     def _get_kwargs_from_urls(urlpath):

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -203,6 +203,33 @@ def test_ls(fs, remote_dir):
     assert dirs == expected
 
 
+def test_walk(fs, remote_dir):
+    fs.mkdir(remote_dir + "/a")
+    fs.mkdir(remote_dir + "/a/b")
+    fs.touch(remote_dir + "/a/f1")
+    fs.touch(remote_dir + "/a/b/f2")
+
+    result = {
+        root: (sorted(dirs), sorted(files))
+        for root, dirs, files in fs.walk(remote_dir + "/a")
+    }
+    assert result == {
+        remote_dir + "/a": (["b"], ["f1"]),
+        remote_dir + "/a/b": ([], ["f2"]),
+    }
+
+
+def test_walk_root(fs):
+    # Regression: SSHFileSystem._strip_protocol("/") used to collapse the
+    # root to "", so walk("/") listed the home directory and yielded
+    # relative paths that were not considered to exist.
+    root, dirs, files = next(iter(fs.walk("/", maxdepth=1, detail=True)))
+    assert root == "/"
+    for info in dirs.values():
+        assert info["name"].startswith("/")
+        assert fs.exists(info["name"])
+
+
 def test_mkdir(fs, remote_dir):
     fs.mkdir(remote_dir + "dir/")
     assert fs.isdir(remote_dir + "dir/")

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -220,14 +220,11 @@ def test_walk(fs, remote_dir):
 
 
 def test_walk_root(fs):
-    # Regression: SSHFileSystem._strip_protocol("/") used to collapse the
-    # root to "", so walk("/") listed the home directory and yielded
-    # relative paths that were not considered to exist.
-    root, dirs, files = next(iter(fs.walk("/", maxdepth=1, detail=True)))
+    # walk("/") must anchor at the root, not the user's home directory.
+    # Only the yielded root is asserted: the mock server exposes the
+    # host's real filesystem, so the contents of "/" are unpredictable.
+    root, _dirs, _files = next(fs.walk("/", maxdepth=1))
     assert root == "/"
-    for info in dirs.values():
-        assert info["name"].startswith("/")
-        assert fs.exists(info["name"])
 
 
 def test_strip_protocol():

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -219,12 +219,12 @@ def test_walk(fs, remote_dir):
     }
 
 
-def test_walk_root(fs):
-    # walk("/") must anchor at the root, not the user's home directory.
-    # Only the yielded root is asserted: the mock server exposes the
-    # host's real filesystem, so the contents of "/" are unpredictable.
-    root, _dirs, _files = next(fs.walk("/", maxdepth=1))
-    assert root == "/"
+def test_root(fs):
+    # An explicit "/" must resolve to the filesystem root, not the
+    # user's home directory.
+    assert fs.exists("/")
+    assert fs.isdir("/")
+    assert fs.info("/")["name"] == "/"
 
 
 def test_strip_protocol():

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -230,6 +230,21 @@ def test_walk_root(fs):
         assert fs.exists(info["name"])
 
 
+def test_strip_protocol():
+    strip = SSHFileSystem._strip_protocol
+    # An explicit absolute root is preserved so walk("/") lists from the root.
+    assert strip("/") == "/"
+    assert strip("ssh://host/") == "/"
+    # Empty and relative paths still resolve against the home directory
+    # instead of being redirected to the root.
+    assert strip("") == ""
+    assert strip("ssh://host") == ""
+    assert strip("foo/bar") == "foo/bar"
+    # Regular absolute paths are unaffected.
+    assert strip("/foo/bar") == "/foo/bar"
+    assert strip("ssh://host/foo/bar") == "/foo/bar"
+
+
 def test_mkdir(fs, remote_dir):
     fs.mkdir(remote_dir + "dir/")
     assert fs.isdir(remote_dir + "dir/")


### PR DESCRIPTION
## Problem
`SSHFileSystem._strip_protocol("/")` collapsed the explicit root down to `""` (the inherited empty `root_marker`). Most SFTP servers, OpenSSH included, reject an empty path with ENOENT for everything except `REALPATH`, so `walk("/")` silently yielded nothing and `exists("/")` / `isdir("/")` returned `False`. Servers implementing the SFTP draft's "empty path = default directory" rule resolved it to the home directory instead.

## Fix
`_strip_protocol` now restores `/` only when the caller explicitly supplied the absolute root:

- explicit absolute root (`/`, `ssh://host/`) → `/`
- empty and relative inputs (`""`, `ssh://host`, `foo/bar`) → unchanged, still resolving against the home directory

Setting `root_marker = "/"` instead would have remapped `""` and bare `ssh://host` from home to root and shifted `_parent()` for relative paths, so the narrower fix was chosen.

## Behavior change
`"/"` now refers to the actual root in every operation that goes through fsspec's path stripping: `exists`, `isdir`, `info`, `walk`, `find`, `glob`, `du`, `get`, `put`, `rm` on `"/"` act on the root tree instead of failing or resolving to `$HOME`. Methods that never stripped paths (`ls`, `mkdir`, `mv`, ...) are unaffected.

## Tests
`walk` coverage over a nested tree, a stat-based root-resolution test (deterministic on any host and any supported fsspec release), and `_strip_protocol` unit tests pinning root/empty/relative/URL behavior.