### PR TITLE
fix: replace deprecated datetime.utcfromtimestamp

### DIFF
--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -4,7 +4,7 @@ import shlex
 import stat
 import weakref
 from contextlib import AsyncExitStack, suppress
-from datetime import datetime
+from datetime import datetime, timezone
 
 import asyncssh
 from asyncssh.sftp import SFTPOpUnsupported
@@ -32,6 +32,11 @@ async_methods.append("_mv")
 # and the rest (generally 8) for SFTP.
 _SHELL_CHANNELS = 2
 _DEFAULT_MAX_SESSIONS = 10
+
+
+def _naive_utc(timestamp):
+    # Naive UTC datetime, matching the historical utcfromtimestamp() output.
+    return datetime.fromtimestamp(timestamp, timezone.utc).replace(tzinfo=None)
 
 
 class SSHFileSystem(AsyncFileSystem):
@@ -151,8 +156,8 @@ class SSHFileSystem(AsyncFileSystem):
             "type": kind,
             "gid": attributes.gid,
             "uid": attributes.uid,
-            "time": datetime.utcfromtimestamp(attributes.atime),
-            "mtime": datetime.utcfromtimestamp(attributes.mtime),
+            "time": _naive_utc(attributes.atime),
+            "mtime": _naive_utc(attributes.mtime),
             "permissions": attributes.permissions,
         }
 

--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -34,11 +34,6 @@ _SHELL_CHANNELS = 2
 _DEFAULT_MAX_SESSIONS = 10
 
 
-def _naive_utc(timestamp):
-    # Naive UTC datetime, matching the historical utcfromtimestamp() output.
-    return datetime.fromtimestamp(timestamp, timezone.utc).replace(tzinfo=None)
-
-
 class SSHFileSystem(AsyncFileSystem):
     def __init__(
         self,
@@ -156,8 +151,16 @@ class SSHFileSystem(AsyncFileSystem):
             "type": kind,
             "gid": attributes.gid,
             "uid": attributes.uid,
-            "time": _naive_utc(attributes.atime),
-            "mtime": _naive_utc(attributes.mtime),
+            "time": (
+                datetime.fromtimestamp(attributes.atime, tz=timezone.utc)
+                if attributes.atime is not None
+                else None
+            ),
+            "mtime": (
+                datetime.fromtimestamp(attributes.mtime, tz=timezone.utc)
+                if attributes.mtime is not None
+                else None
+            ),
             "permissions": attributes.permissions,
         }
 

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -4,12 +4,12 @@ import secrets
 import tempfile
 import warnings
 from concurrent import futures
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import fsspec
 import pytest
-from asyncssh.sftp import SFTPFailure
+from asyncssh.sftp import SFTPAttrs, SFTPFailure
 from importlib_metadata import entry_points
 
 from sshfs import SSHFileSystem
@@ -114,6 +114,22 @@ def test_info(fs, remote_dir):
 
     details = fs.info(remote_dir + "/dir/")
     assert details["name"] == remote_dir + "/dir/"
+
+
+def test_info_timestamps_are_tz_aware_utc(fs, remote_dir):
+    fs.touch(remote_dir + "/a.txt")
+    details = fs.info(remote_dir + "/a.txt")
+    for key in ["time", "mtime"]:
+        assert details[key].tzinfo == timezone.utc
+
+
+def test_decode_attributes_missing_timestamps(fs):
+    attrs = SFTPAttrs(
+        permissions=0o100644, size=0, uid=0, gid=0, atime=None, mtime=None
+    )
+    details = fs._decode_attributes(attrs)
+    assert details["time"] is None
+    assert details["mtime"] is None
 
 
 def test_move(fs, remote_dir):


### PR DESCRIPTION
`datetime.utcfromtimestamp()` is deprecated since Python 3.12 and slated for removal. `SSHFileSystem._decode_attributes()` used it to decode SFTP `atime`/`mtime`, so every `info()`/`ls(detail=True)`/`modified()` call emits a `DeprecationWarning` on modern Python and will break outright once the function is removed.

This PR replaces it with `datetime.fromtimestamp(ts, tz=timezone.utc)`.

**Behavior changes** (⚠️ for downstream consumers):

- `info()["time"]`, `info()["mtime"]` and `modified()` now return **timezone-aware UTC** datetimes instead of naive ones. The instant represented is identical; only `tzinfo` changed. This aligns sshfs with `fsspec`'s own `LocalFileSystem` and `sftp` implementations. Code that compares these values against naive datetimes will now raise `TypeError` and should switch to aware datetimes (e.g. `datetime.now(timezone.utc)`).
- `atime`/`mtime` missing from the server response now yield `None` instead of raising `TypeError` (`SFTPAttrs` fields are optional).

**Tests:**

- `info()` timestamps are asserted to be tz-aware UTC, locking in the new contract.
- `_decode_attributes()` with `SFTPAttrs(atime=None, mtime=None)` returns `None` for both fields.
