### PR TITLE
ci: make the intermittent connect hang diagnosable and self-healing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,12 @@ jobs:
         python -m pip install -e .
 
     - name: Test
-      timeout-minutes: 1
-      run: python -m pytest --cov-report=xml --cov=.
+      # Leave room for faulthandler_timeout (60s) to dump stacks and for
+      # asyncssh's login_timeout (120s) to raise before the step is killed.
+      timeout-minutes: 3
+      run: >-
+        python -m pytest --cov-report=xml --cov=.
+        --reruns 1 --reruns-delay 2
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,13 @@ namespaces = false
 
 [tool.setuptools_scm]
 
+[tool.pytest.ini_options]
+# The suite intermittently hangs on the first SSH connection against
+# mock-ssh-server (Linux only). Dump all thread stacks when a test
+# exceeds this, so a hang in CI is diagnosable instead of a mute
+# step-timeout kill.
+faulthandler_timeout = 60
+
 [tool.black]
 line-length = 79
 target-version = ['py39']

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 pytest
 pytest-asyncio
 pytest-cov
+pytest-rerunfailures
 mock-ssh-server
 importlib-metadata >= 6.0.0


### PR DESCRIPTION
## Problem
The test suite intermittently freezes at its first SSH connection against mock-ssh-server — always exactly one **ubuntu** job per run, random Python version, never macOS. Scheduled runs show it across months (Apr 26, Jul 25, Jul 27–28, and Aug 1–4 were four red nightlies in a row). Because the `Test` step has `timeout-minutes: 1`, the job is killed before anything can report: every failure is a mute freeze right after `test_sftp_pools.py`, with no traceback.

The suite opens essentially one real SSH connection (fsspec's instance cache reuses the filesystem across tests), so the hang always lands on the session's first `test_sshfs.py` test. asyncssh's `login_timeout` (120s) would raise a diagnosable error on a stalled handshake, but the 60s step axe always wins.

## Change
- `faulthandler_timeout = 60` in pytest config: a test stalling for a minute dumps **all thread stacks** to the log, so the next occurrence tells us exactly where it is stuck (asyncssh handshake vs mockssh/paramiko accept thread).
- `timeout-minutes: 1 → 3` on the Test step: leaves room for the dump and for `login_timeout` to fire.
- `--reruns 1 --reruns-delay 2` (pytest-rerunfailures): a transient hang no longer reddens the whole run — the stack dump stays in the log while the retried test goes green.

This intentionally does not claim to fix the underlying race (mock-ssh-server is unmaintained); it converts an opaque recurring red into either a self-healed run with evidence in the log, or a real traceback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)