### PR TITLE
Fix ls detail default

### DIFF
--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -265,7 +265,7 @@ class SSHFileSystem(AsyncFileSystem):
         await self._execute(cmd)
 
     @wrap_exceptions
-    async def _ls(self, path, detail=False, **kwargs):
+    async def _ls(self, path, detail=True, **kwargs):
         async with self._pool.get() as channel:
             file_attrs = await channel.readdir(path)
 

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -136,7 +136,7 @@ def test_sftp_client_kwargs_path_encoding(
     (directory / "data.txt").write_bytes(b"data")
 
     encoded = str(directory).encode()
-    assert fs.ls(encoded) == [encoded + b"/data.txt"]
+    assert fs.ls(encoded, detail=False) == [encoded + b"/data.txt"]
     assert fs.cat_file(encoded + b"/data.txt") == b"data"
 
 
@@ -247,9 +247,9 @@ def test_ls(fs, remote_dir):
         fs.touch(file)
         files.add(file)
 
-    assert set(fs.ls(remote_dir + "dir/")) == files
+    assert set(fs.ls(remote_dir + "dir/", detail=False)) == files
 
-    dirs = fs.ls(remote_dir + "dir/", detail=True)
+    dirs = fs.ls(remote_dir + "dir/")
     expected = [fs.info(file) for file in files]
 
     by_name = lambda details: details["name"]


### PR DESCRIPTION
Fixes #48.

This makes ls() default to returning detail dictionaries, matching fsspec's expected default, while keeping detail=False returning names only.

Tested with:

```powershell
python -m pytest tests/test_sshfs.py::test_ls tests/test_sshfs.py::test_sftp_client_kwargs_path_encoding -q
```