### PR TITLE
Use the copy-data extension for cp_file when the server supports it

### DIFF
--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -261,6 +261,15 @@ class SSHFileSystem(AsyncFileSystem):
 
     @wrap_exceptions
     async def _cp_file(self, lpath, rpath, **kwargs):
+        # Server-side copy through the copy-data extension (asyncssh >=
+        # 2.19 with an OpenSSH >= 9.0 server) needs no shell access and
+        # keeps the data on the server. remote_only guards against
+        # asyncssh silently copying through the client instead. Without
+        # the extension, fall back to a shell cp.
+        async with self._pool.get() as channel:
+            if getattr(channel, "supports_remote_copy", False):
+                return await channel.copy(lpath, rpath, remote_only=True)
+
         cmd = f"cp {shlex.quote(lpath)} {shlex.quote(rpath)}"
         await self._execute(cmd)
 

--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -1,6 +1,5 @@
 import asyncio
 import posixpath
-import secrets
 import shlex
 import shutil
 import stat
@@ -10,7 +9,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 import asyncssh
-from asyncssh.sftp import SFTPNoSuchFile, SFTPOpUnsupported
+from asyncssh.sftp import SFTPOpUnsupported
 from fsspec.asyn import (
     AsyncFileSystem,
     FSTimeoutError,
@@ -263,65 +262,60 @@ class SSHFileSystem(AsyncFileSystem):
             )
 
     async def _remote_copy_file(self, channel, lpath, rpath):
-        # copy-data must never be pointed at an aliased destination:
-        # asyncssh opens it with truncation and would destroy the
-        # source, where shell cp refuses the copy. The realpath
-        # comparison (normalized to bytes: realpath preserves the
-        # str/bytes type of its argument) catches path and symlink
-        # aliases; hardlinks carry no inode over SFTP and cannot be
-        # detected, so the data is written to a temporary name and
-        # renamed over the destination, which is safe for any alias.
+        # The data is written through the destination's existing file
+        # (FXF_CREAT without FXF_TRUNC, truncated to the source length
+        # afterwards), never by replacing its directory entry. That is
+        # cp's own contract: the destination inode with its mode,
+        # owner, xattrs and hardlink peers survives, a read-only
+        # destination is refused at open, and a new file's requested
+        # mode passes through the server's umask. It also makes
+        # aliases safe by construction -- copying a file onto itself
+        # writes its bytes over themselves and the final truncation to
+        # its own length changes nothing -- which matters because
+        # hardlink aliases carry no inode over SFTP and cannot be
+        # detected. Detectable aliases (path and symlink, compared via
+        # realpath normalized to bytes: realpath preserves the
+        # str/bytes type of its argument) are refused like cp refuses
+        # them.
         src, dst = await asyncio.gather(
             channel.realpath(lpath), channel.realpath(rpath)
         )
-        src, dst = channel.encode(src), channel.encode(dst)
-
-        # A directory destination means "copy into": like cp, resolve
-        # it against the source's basename. isdir() is False for
-        # missing paths and checks the file type on every SFTP version
-        # (v4+ attributes carry no type bits in `permissions`).
-        if await channel.isdir(dst):
-            dst = channel.encode(
-                await channel.realpath(
-                    posixpath.join(
-                        dst, posixpath.basename(channel.encode(lpath))
-                    )
-                )
-            )
-
-        if src == dst:
+        if channel.encode(src) == channel.encode(dst):
             raise shutil.SameFileError(
                 f"{lpath!r} and {rpath!r} are the same file"
             )
 
-        # cp keeps an existing destination's mode and gives a new file
-        # the source's mode (the remote umask is unknowable over SFTP
-        # and cannot be applied). The mode is set on the temporary file
-        # before the rename, so a failure never leaves the destination
-        # changed. Timestamps are deliberately not preserved, like cp.
-        src_attrs = await channel.stat(lpath)
-        dst_attrs = None
-        with suppress(SFTPNoSuchFile):
-            dst_attrs = await channel.stat(dst)
-        mode = (dst_attrs or src_attrs).permissions & 0o7777
-
-        tmp = dst + f".{secrets.token_hex(8)}.part".encode()
-        try:
-            await channel.copy(
-                lpath, tmp, follow_symlinks=True, remote_only=True
+        # A directory destination means "copy into": like cp, resolve
+        # it against the source's basename. The copy itself keeps the
+        # requested path -- canonicalizing it would change meaning for
+        # trailing slashes and symlinks. isdir() checks the file type
+        # on every SFTP version (v4+ attributes carry no type bits in
+        # `permissions`) and is False for missing paths.
+        if await channel.isdir(rpath):
+            rpath = posixpath.join(
+                channel.encode(rpath),
+                posixpath.basename(channel.encode(lpath)),
             )
-            await channel.setstat(tmp, asyncssh.SFTPAttrs(permissions=mode))
-            try:
-                await channel.posix_rename(tmp, dst)
-            except SFTPOpUnsupported:
-                # SFTPv3 RENAME refuses existing destinations.
-                with suppress(SFTPNoSuchFile):
-                    await channel.remove(dst)
-                await channel.rename(tmp, dst)
-        except BaseException:
-            with suppress(Exception):
-                await channel.remove(tmp)
-            raise
+            resolved = await channel.realpath(rpath)
+            if channel.encode(src) == channel.encode(resolved):
+                raise shutil.SameFileError(
+                    f"{lpath!r} and {rpath!r} are the same file"
+                )
+
+        async with channel.open(lpath, "rb", block_size=0) as src_file:
+            src_attrs = await src_file.stat()
+            # Like cp for new files: special bits stripped, and the
+            # server applies its umask to the requested mode. Existing
+            # destinations keep their attributes untouched.
+            mode = (src_attrs.permissions or 0o666) & 0o777
+            async with channel.open(
+                rpath,
+                asyncssh.FXF_WRITE | asyncssh.FXF_CREAT,
+                asyncssh.SFTPAttrs(permissions=mode),
+                block_size=0,
+            ) as dst_file:
+                await channel.remote_copy(src_file, dst_file)
+                await dst_file.truncate(src_attrs.size)
 
     @wrap_exceptions
     async def _cp_file(self, lpath, rpath, **kwargs):

--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -260,6 +260,24 @@ class SSHFileSystem(AsyncFileSystem):
                 progress_handler=as_progress_handler(callback),
             )
 
+    @staticmethod
+    def _shell_paths(*paths):
+        # Shell commands are text. Byte paths are decoded as UTF-8;
+        # paths that are not valid UTF-8 can only be used with the
+        # operations that stay on the SFTP channel.
+        decoded = []
+        for path in paths:
+            if isinstance(path, bytes):
+                try:
+                    path = path.decode("utf-8")
+                except UnicodeDecodeError as exc:
+                    raise ValueError(
+                        f"{path!r} is not valid UTF-8 and cannot be used "
+                        "in a shell command"
+                    ) from exc
+            decoded.append(path)
+        return decoded
+
     async def _remote_copy_file(self, channel, lpath, rpath):
         """Copy over the copy-data extension. Returns False when the
         copy must be handled by the shell fallback instead."""
@@ -366,13 +384,7 @@ class SSHFileSystem(AsyncFileSystem):
                 ):
                     return
 
-        # The shell command needs text: bytes paths are decoded as
-        # UTF-8. Non-UTF-8 byte paths cannot ride a shell command and
-        # only work on operations that stay on the SFTP channel.
-        if isinstance(lpath, bytes):
-            lpath = lpath.decode("utf-8")
-        if isinstance(rpath, bytes):
-            rpath = rpath.decode("utf-8")
+        lpath, rpath = self._shell_paths(lpath, rpath)
         cmd = f"cp {shlex.quote(lpath)} {shlex.quote(rpath)}"
         await self._execute(cmd)
 

--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -79,6 +79,8 @@ class SSHFileSystem(AsyncFileSystem):
 
         self._stack = AsyncExitStack()
         self.active_executors = 0
+        # None means "not probed yet"; resolved on first _cp_file call.
+        self._supports_remote_copy = None
         self._client, self._pool = self.connect(
             host,
             pool_type,
@@ -264,11 +266,18 @@ class SSHFileSystem(AsyncFileSystem):
         # Server-side copy through the copy-data extension (asyncssh >=
         # 2.19 with an OpenSSH >= 9.0 server) needs no shell access and
         # keeps the data on the server. remote_only guards against
-        # asyncssh silently copying through the client instead. Without
-        # the extension, fall back to a shell cp.
-        async with self._pool.get() as channel:
-            if getattr(channel, "supports_remote_copy", False):
-                return await channel.copy(lpath, rpath, remote_only=True)
+        # asyncssh silently copying through the client instead. The
+        # capability is per-connection, so it is cached after the first
+        # probe and the shell fallback never touches the channel pool
+        # again. Without the extension, fall back to a shell cp.
+        if self._supports_remote_copy is not False:
+            async with self._pool.get() as channel:
+                if self._supports_remote_copy is None:
+                    self._supports_remote_copy = getattr(
+                        channel, "supports_remote_copy", False
+                    )
+                if self._supports_remote_copy:
+                    return await channel.copy(lpath, rpath, remote_only=True)
 
         cmd = f"cp {shlex.quote(lpath)} {shlex.quote(rpath)}"
         await self._execute(cmd)

--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -1,5 +1,6 @@
 import asyncio
 import posixpath
+import secrets
 import shlex
 import shutil
 import stat
@@ -225,12 +226,11 @@ class SSHFileSystem(AsyncFileSystem):
         # Some systems doesn't natively support posix_rename
         # which is an extension to the original SFTP protocol.
         # In that case we are going to copy the file and delete
-        # it.
+        # it. The source must only be removed after the copy fully
+        # succeeded.
 
-        try:
-            await self._cp_file(lpath, rpath)
-        finally:
-            await self._rm_file(lpath)
+        await self._cp_file(lpath, rpath)
+        await self._rm_file(lpath)
 
     @wrap_exceptions
     async def _put_file(
@@ -262,15 +262,75 @@ class SSHFileSystem(AsyncFileSystem):
                 progress_handler=as_progress_handler(callback),
             )
 
+    async def _remote_copy_file(self, channel, lpath, rpath):
+        # copy-data must never be pointed at an aliased destination:
+        # asyncssh opens it with truncation and would destroy the
+        # source, where shell cp refuses the copy. The realpath
+        # comparison (normalized to bytes: realpath preserves the
+        # str/bytes type of its argument) catches path and symlink
+        # aliases; hardlinks carry no inode over SFTP and cannot be
+        # detected, so the data is written to a temporary name and
+        # renamed over the destination, which is safe for any alias.
+        src, dst = await asyncio.gather(
+            channel.realpath(lpath), channel.realpath(rpath)
+        )
+        src, dst = channel.encode(src), channel.encode(dst)
+
+        # A directory destination means "copy into": like cp, resolve
+        # it against the source's basename. isdir() is False for
+        # missing paths and checks the file type on every SFTP version
+        # (v4+ attributes carry no type bits in `permissions`).
+        if await channel.isdir(dst):
+            dst = channel.encode(
+                await channel.realpath(
+                    posixpath.join(
+                        dst, posixpath.basename(channel.encode(lpath))
+                    )
+                )
+            )
+
+        if src == dst:
+            raise shutil.SameFileError(
+                f"{lpath!r} and {rpath!r} are the same file"
+            )
+
+        # cp keeps an existing destination's mode and gives a new file
+        # the source's mode (the remote umask is unknowable over SFTP
+        # and cannot be applied). The mode is set on the temporary file
+        # before the rename, so a failure never leaves the destination
+        # changed. Timestamps are deliberately not preserved, like cp.
+        src_attrs = await channel.stat(lpath)
+        dst_attrs = None
+        with suppress(SFTPNoSuchFile):
+            dst_attrs = await channel.stat(dst)
+        mode = (dst_attrs or src_attrs).permissions & 0o7777
+
+        tmp = dst + f".{secrets.token_hex(8)}.part".encode()
+        try:
+            await channel.copy(
+                lpath, tmp, follow_symlinks=True, remote_only=True
+            )
+            await channel.setstat(tmp, asyncssh.SFTPAttrs(permissions=mode))
+            try:
+                await channel.posix_rename(tmp, dst)
+            except SFTPOpUnsupported:
+                # SFTPv3 RENAME refuses existing destinations.
+                with suppress(SFTPNoSuchFile):
+                    await channel.remove(dst)
+                await channel.rename(tmp, dst)
+        except BaseException:
+            with suppress(Exception):
+                await channel.remove(tmp)
+            raise
+
     @wrap_exceptions
     async def _cp_file(self, lpath, rpath, **kwargs):
         # Server-side copy through the copy-data extension (asyncssh >=
         # 2.19 with an OpenSSH >= 9.0 server) needs no shell access and
-        # keeps the data on the server. remote_only guards against
-        # asyncssh silently copying through the client instead. The
-        # capability is per-connection, so it is cached after the first
-        # probe and the shell fallback never touches the channel pool
-        # again. Without the extension, fall back to a shell cp.
+        # keeps the data on the server. The capability is
+        # per-connection, so it is cached after the first probe and the
+        # shell fallback never touches the channel pool again. Without
+        # the extension, fall back to a shell cp.
         if self._supports_remote_copy is not False:
             async with self._pool.get() as channel:
                 if self._supports_remote_copy is None:
@@ -278,42 +338,7 @@ class SSHFileSystem(AsyncFileSystem):
                         channel, "supports_remote_copy", False
                     )
                 if self._supports_remote_copy:
-                    # The remote copy handles only the plain
-                    # file-to-file form. A directory destination means
-                    # "copy into" with cp's resolution rules (including
-                    # its same-file protections), so that form is
-                    # delegated to the shell fallback below.
-                    dst_attrs = None
-                    with suppress(SFTPNoSuchFile):
-                        dst_attrs = await channel.stat(rpath)
-                    if dst_attrs is None or not stat.S_ISDIR(
-                        dst_attrs.permissions
-                    ):
-                        # asyncssh opens the destination with truncation
-                        # and no same-file check, so aliased paths (same
-                        # path or a symlink to the source) would destroy
-                        # the source; shell cp refuses them instead.
-                        # Hardlink aliases cannot be detected over SFTP
-                        # (no inode in attrs).
-                        src, dst = await asyncio.gather(
-                            channel.realpath(lpath),
-                            channel.realpath(rpath),
-                        )
-                        if src == dst:
-                            raise shutil.SameFileError(
-                                f"{lpath!r} and {rpath!r} " "are the same file"
-                            )
-                        # preserve and follow_symlinks match what the
-                        # shell cp fallback does: copy the link
-                        # target's content and keep the source
-                        # permissions.
-                        return await channel.copy(
-                            lpath,
-                            rpath,
-                            preserve=True,
-                            follow_symlinks=True,
-                            remote_only=True,
-                        )
+                    return await self._remote_copy_file(channel, lpath, rpath)
 
         cmd = f"cp {shlex.quote(lpath)} {shlex.quote(rpath)}"
         await self._execute(cmd)

--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -1,7 +1,6 @@
 import asyncio
 import posixpath
 import shlex
-import shutil
 import stat
 import weakref
 from contextlib import AsyncExitStack, suppress
@@ -9,7 +8,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 import asyncssh
-from asyncssh.sftp import SFTPOpUnsupported
+from asyncssh.sftp import SFTPError, SFTPOpUnsupported, SFTPPermissionDenied
 from fsspec.asyn import (
     AsyncFileSystem,
     FSTimeoutError,
@@ -262,60 +261,80 @@ class SSHFileSystem(AsyncFileSystem):
             )
 
     async def _remote_copy_file(self, channel, lpath, rpath):
-        # The data is written through the destination's existing file
-        # (FXF_CREAT without FXF_TRUNC, truncated to the source length
-        # afterwards), never by replacing its directory entry. That is
-        # cp's own contract: the destination inode with its mode,
-        # owner, xattrs and hardlink peers survives, a read-only
-        # destination is refused at open, and a new file's requested
-        # mode passes through the server's umask. It also makes
-        # aliases safe by construction -- copying a file onto itself
-        # writes its bytes over themselves and the final truncation to
-        # its own length changes nothing -- which matters because
-        # hardlink aliases carry no inode over SFTP and cannot be
-        # detected. Detectable aliases (path and symlink, compared via
-        # realpath normalized to bytes: realpath preserves the
-        # str/bytes type of its argument) are refused like cp refuses
-        # them.
-        src, dst = await asyncio.gather(
-            channel.realpath(lpath), channel.realpath(rpath)
-        )
-        if channel.encode(src) == channel.encode(dst):
-            raise shutil.SameFileError(
-                f"{lpath!r} and {rpath!r} are the same file"
-            )
+        """Copy over the copy-data extension. Returns False when the
+        copy must be handled by the shell fallback instead."""
+        # The remote copy only ever CREATES the destination (FXF_EXCL)
+        # and copies until the source's end of file. Everything an
+        # in-place overwrite would need is unsolvable over SFTP: a
+        # stale pre-copy size corrupts sources whose stat lies (procfs)
+        # or that change while copying, a post-copy truncate can be
+        # denied (fsetstat policy) after the destination was already
+        # modified, a pre-copy truncate destroys sources aliased behind
+        # an undetectable hardlink, and replacing the directory entry
+        # loses the inode. Existing destinations therefore go to the
+        # shell fallback, whose cp implements those semantics natively.
+        # FXF_EXCL also refuses to create through a dangling symlink,
+        # and guarantees a failed copy can be cleaned up completely --
+        # the file it made is ours.
 
         # A directory destination means "copy into": like cp, resolve
-        # it against the source's basename. The copy itself keeps the
-        # requested path -- canonicalizing it would change meaning for
-        # trailing slashes and symlinks. isdir() checks the file type
-        # on every SFTP version (v4+ attributes carry no type bits in
-        # `permissions`) and is False for missing paths.
+        # it against the source's basename. isdir() checks the file
+        # type on every SFTP version (v4+ attributes carry no type bits
+        # in `permissions`) and is False for missing paths.
         if await channel.isdir(rpath):
             rpath = posixpath.join(
                 channel.encode(rpath),
                 posixpath.basename(channel.encode(lpath)),
             )
-            resolved = await channel.realpath(rpath)
-            if channel.encode(src) == channel.encode(resolved):
-                raise shutil.SameFileError(
-                    f"{lpath!r} and {rpath!r} are the same file"
-                )
 
+        # The source is opened before the destination is created so
+        # that a missing source cannot leave an empty destination.
         async with channel.open(lpath, "rb", block_size=0) as src_file:
             src_attrs = await src_file.stat()
             # Like cp for new files: special bits stripped, and the
-            # server applies its umask to the requested mode. Existing
-            # destinations keep their attributes untouched.
-            mode = (src_attrs.permissions or 0o666) & 0o777
-            async with channel.open(
-                rpath,
-                asyncssh.FXF_WRITE | asyncssh.FXF_CREAT,
-                asyncssh.SFTPAttrs(permissions=mode),
-                block_size=0,
-            ) as dst_file:
+            # server applies its umask to the requested mode. A mode of
+            # 0 is a valid mode, only a missing one falls back to the
+            # server default.
+            if src_attrs.permissions is None:
+                attrs = asyncssh.SFTPAttrs()
+            else:
+                attrs = asyncssh.SFTPAttrs(
+                    permissions=src_attrs.permissions & 0o777
+                )
+            try:
+                dst_file = await channel.open(
+                    rpath,
+                    asyncssh.FXF_WRITE
+                    | asyncssh.FXF_CREAT
+                    | asyncssh.FXF_EXCL,
+                    attrs,
+                    block_size=0,
+                )
+            except (OSError, SFTPError):
+                # Existing destination (any alias of the source is one),
+                # dangling symlink, missing parent, trailing slash on a
+                # file: the shell fallback owns these forms.
+                return False
+
+            try:
                 await channel.remote_copy(src_file, dst_file)
-                await dst_file.truncate(src_attrs.size)
+            except (SFTPOpUnsupported, SFTPPermissionDenied):
+                # Advertised but denied (e.g. an OpenSSH allow/deny
+                # policy): remove the file we created and stop trying
+                # the extension on this connection.
+                await dst_file.close()
+                with suppress(OSError, SFTPError):
+                    await channel.remove(rpath)
+                self._supports_remote_copy = False
+                return False
+            except BaseException:
+                await dst_file.close()
+                with suppress(OSError, SFTPError):
+                    await channel.remove(rpath)
+                raise
+            else:
+                await dst_file.close()
+        return True
 
     @wrap_exceptions
     async def _cp_file(self, lpath, rpath, **kwargs):
@@ -323,17 +342,27 @@ class SSHFileSystem(AsyncFileSystem):
         # 2.19 with an OpenSSH >= 9.0 server) needs no shell access and
         # keeps the data on the server. The capability is
         # per-connection, so it is cached after the first probe and the
-        # shell fallback never touches the channel pool again. Without
-        # the extension, fall back to a shell cp.
+        # shell fallback never touches the channel pool again. The
+        # extension path only creates new destinations; everything else
+        # falls back to a shell cp.
         if self._supports_remote_copy is not False:
             async with self._pool.get() as channel:
                 if self._supports_remote_copy is None:
                     self._supports_remote_copy = getattr(
                         channel, "supports_remote_copy", False
                     )
-                if self._supports_remote_copy:
-                    return await self._remote_copy_file(channel, lpath, rpath)
+                if (
+                    self._supports_remote_copy
+                    and await self._remote_copy_file(channel, lpath, rpath)
+                ):
+                    return
 
+        # The shell command needs text; bytes paths (accepted by the
+        # SFTP operations) are decoded with the SFTP default encoding.
+        if isinstance(lpath, bytes):
+            lpath = lpath.decode("utf-8")
+        if isinstance(rpath, bytes):
+            rpath = rpath.decode("utf-8")
         cmd = f"cp {shlex.quote(lpath)} {shlex.quote(rpath)}"
         await self._execute(cmd)
 

--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -8,7 +8,17 @@ from datetime import datetime, timezone
 from typing import Optional
 
 import asyncssh
-from asyncssh.sftp import SFTPError, SFTPOpUnsupported, SFTPPermissionDenied
+from asyncssh.sftp import (
+    FILEXFER_TYPE_DIRECTORY,
+    FILEXFER_TYPE_REGULAR,
+    FILEXFER_TYPE_SYMLINK,
+    FILEXFER_TYPE_UNKNOWN,
+    SFTPError,
+    SFTPFailure,
+    SFTPFileAlreadyExists,
+    SFTPOpUnsupported,
+    SFTPPermissionDenied,
+)
 from fsspec.asyn import (
     AsyncFileSystem,
     FSTimeoutError,
@@ -28,6 +38,12 @@ from sshfs.utils import (
 )
 
 async_methods.append("_mv")
+
+_FILE_TYPES = {
+    FILEXFER_TYPE_REGULAR: "file",
+    FILEXFER_TYPE_DIRECTORY: "directory",
+    FILEXFER_TYPE_SYMLINK: "link",
+}
 
 # Always allocate 2 channels for shell operations
 # and the rest (generally 8) for SFTP.
@@ -168,7 +184,13 @@ class SSHFileSystem(AsyncFileSystem):
         return self._client
 
     def _decode_attributes(self, attributes):
-        if stat.S_ISDIR(attributes.permissions):
+        # SFTP v4 and later carry the file type in its own field and
+        # leave only the permission bits in `permissions`, so the type
+        # has to be read from there when the server reports one.
+        file_type = getattr(attributes, "type", FILEXFER_TYPE_UNKNOWN)
+        if file_type != FILEXFER_TYPE_UNKNOWN:
+            kind = _FILE_TYPES.get(file_type, "unknown")
+        elif stat.S_ISDIR(attributes.permissions):
             kind = "directory"
         elif stat.S_ISREG(attributes.permissions):
             kind = "file"
@@ -224,19 +246,29 @@ class SSHFileSystem(AsyncFileSystem):
             with suppress(SFTPOpUnsupported):
                 return await channel.posix_rename(lpath, rpath)
 
-            # The standard rename is still a rename: it keeps the
-            # object's identity (symlinks stay symlinks, hardlinks keep
-            # their inode and their special bits) and cannot lose data.
-            # It refuses an existing destination, which is the case the
-            # copy below has to handle.
-            with suppress(OSError, SFTPError):
+            # The standard rename keeps the object's identity
+            # (symlinks stay symlinks, hardlinks keep their inode and
+            # their special bits) and cannot lose data. Only the
+            # statuses that a rename returns for "cannot rename these
+            # operands" -- an existing destination, a cross-device
+            # move, an unimplemented request -- fall through to the
+            # shell below; permission, missing-file and transport
+            # errors are the caller's answer.
+            with suppress(
+                SFTPFailure, SFTPFileAlreadyExists, SFTPOpUnsupported
+            ):
                 return await channel.rename(lpath, rpath)
 
-        # Neither rename is available for these operands, so fall back
-        # to copying and removing. The source must only be removed
-        # after the copy fully succeeded.
-        await self._cp_file(lpath, rpath)
-        await self._rm_file(lpath)
+        # Neither rename applies, so let the remote mv do it. Copying
+        # and deleting the source here would be unsafe: a successful
+        # copy only proves that the bytes reached an open handle, not
+        # that the destination path still names it, so the source could
+        # be removed after its data ended up somewhere unreachable. On
+        # a server without shell access this raises instead, leaving
+        # the source untouched.
+        lpath, rpath = self._shell_paths(lpath, rpath)
+        cmd = f"mv -- {shlex.quote(lpath)} {shlex.quote(rpath)}"
+        await self._execute(cmd)
 
     @wrap_exceptions
     async def _put_file(
@@ -329,15 +361,12 @@ class SSHFileSystem(AsyncFileSystem):
             # never with the server's default: servers may deny fstat
             # (OpenSSH -P fstat) while allowing the copy, and defaulting
             # to a world-readable mode would publish the contents of a
-            # private source. Owner-write is always requested so that
-            # the shell fallback can still write the file if the copy
-            # is denied; a source without owner-write therefore gains
-            # that single bit.
+            # private source.
             mode = 0o600
             with suppress(OSError, SFTPError):
                 src_attrs = await src_file.stat()
                 if src_attrs.permissions is not None:
-                    mode = (src_attrs.permissions & 0o777) | 0o200
+                    mode = src_attrs.permissions & 0o777
             attrs = asyncssh.SFTPAttrs(permissions=mode)
             try:
                 dst_file = await channel.open(

--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -273,9 +273,14 @@ class SSHFileSystem(AsyncFileSystem):
         # an undetectable hardlink, and replacing the directory entry
         # loses the inode. Existing destinations therefore go to the
         # shell fallback, whose cp implements those semantics natively.
-        # FXF_EXCL also refuses to create through a dangling symlink,
-        # and guarantees a failed copy can be cleaned up completely --
-        # the file it made is ours.
+        # FXF_EXCL also refuses to create through a dangling symlink.
+        #
+        # A failed or interrupted copy may leave a partial destination
+        # behind, exactly like an interrupted cp. It is deliberately
+        # never unlinked: FXF_EXCL proves this client created the
+        # inode, but over SFTP the pathname cannot be re-verified to
+        # still name that inode at cleanup time, so removing it could
+        # delete an unrelated file that raced onto the same name.
 
         # A directory destination means "copy into": like cp, resolve
         # it against the source's basename. isdir() checks the file
@@ -289,18 +294,19 @@ class SSHFileSystem(AsyncFileSystem):
 
         # The source is opened before the destination is created so
         # that a missing source cannot leave an empty destination.
-        async with channel.open(lpath, "rb", block_size=0) as src_file:
-            src_attrs = await src_file.stat()
+        src_file = await channel.open(lpath, "rb", block_size=0)
+        try:
             # Like cp for new files: special bits stripped, and the
             # server applies its umask to the requested mode. A mode of
-            # 0 is a valid mode, only a missing one falls back to the
-            # server default.
-            if src_attrs.permissions is None:
-                attrs = asyncssh.SFTPAttrs()
-            else:
-                attrs = asyncssh.SFTPAttrs(
-                    permissions=src_attrs.permissions & 0o777
-                )
+            # 0 is a valid mode; a missing one -- or a server that
+            # denies fstat -- falls back to the server default.
+            attrs = asyncssh.SFTPAttrs()
+            with suppress(OSError, SFTPError):
+                src_attrs = await src_file.stat()
+                if src_attrs.permissions is not None:
+                    attrs = asyncssh.SFTPAttrs(
+                        permissions=src_attrs.permissions & 0o777
+                    )
             try:
                 dst_file = await channel.open(
                     rpath,
@@ -320,20 +326,23 @@ class SSHFileSystem(AsyncFileSystem):
                 await channel.remote_copy(src_file, dst_file)
             except (SFTPOpUnsupported, SFTPPermissionDenied):
                 # Advertised but denied (e.g. an OpenSSH allow/deny
-                # policy): remove the file we created and stop trying
-                # the extension on this connection.
-                await dst_file.close()
-                with suppress(OSError, SFTPError):
-                    await channel.remove(rpath)
+                # policy): stop trying the extension on this connection
+                # and let the shell cp overwrite the empty file just
+                # created.
                 self._supports_remote_copy = False
+                with suppress(OSError, SFTPError):
+                    await dst_file.close()
                 return False
             except BaseException:
-                await dst_file.close()
                 with suppress(OSError, SFTPError):
-                    await channel.remove(rpath)
+                    await dst_file.close()
                 raise
-            else:
-                await dst_file.close()
+            # A close failure after writing must surface: the data may
+            # not be durable.
+            await dst_file.close()
+        finally:
+            with suppress(OSError, SFTPError):
+                await src_file.close()
         return True
 
     @wrap_exceptions
@@ -357,8 +366,9 @@ class SSHFileSystem(AsyncFileSystem):
                 ):
                     return
 
-        # The shell command needs text; bytes paths (accepted by the
-        # SFTP operations) are decoded with the SFTP default encoding.
+        # The shell command needs text: bytes paths are decoded as
+        # UTF-8. Non-UTF-8 byte paths cannot ride a shell command and
+        # only work on operations that stay on the SFTP channel.
         if isinstance(lpath, bytes):
             lpath = lpath.decode("utf-8")
         if isinstance(rpath, bytes):

--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -1,6 +1,7 @@
 import asyncio
 import posixpath
 import shlex
+import shutil
 import stat
 import weakref
 from contextlib import AsyncExitStack, suppress
@@ -277,7 +278,28 @@ class SSHFileSystem(AsyncFileSystem):
                         channel, "supports_remote_copy", False
                     )
                 if self._supports_remote_copy:
-                    return await channel.copy(lpath, rpath, remote_only=True)
+                    # asyncssh opens the destination with truncation and
+                    # no same-file check, so aliased paths (same path or
+                    # a symlink to the source) would destroy the source;
+                    # shell cp refuses them instead. Hardlink aliases
+                    # cannot be detected over SFTP (no inode in attrs).
+                    src, dst = await asyncio.gather(
+                        channel.realpath(lpath), channel.realpath(rpath)
+                    )
+                    if src == dst:
+                        raise shutil.SameFileError(
+                            f"{lpath!r} and {rpath!r} are the same file"
+                        )
+                    # preserve and follow_symlinks match what the shell
+                    # cp fallback does: copy the link target's content
+                    # and keep the source permissions.
+                    return await channel.copy(
+                        lpath,
+                        rpath,
+                        preserve=True,
+                        follow_symlinks=True,
+                        remote_only=True,
+                    )
 
         cmd = f"cp {shlex.quote(lpath)} {shlex.quote(rpath)}"
         await self._execute(cmd)

--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from typing import Optional
 
 import asyncssh
-from asyncssh.sftp import SFTPOpUnsupported
+from asyncssh.sftp import SFTPNoSuchFile, SFTPOpUnsupported
 from fsspec.asyn import (
     AsyncFileSystem,
     FSTimeoutError,
@@ -278,28 +278,42 @@ class SSHFileSystem(AsyncFileSystem):
                         channel, "supports_remote_copy", False
                     )
                 if self._supports_remote_copy:
-                    # asyncssh opens the destination with truncation and
-                    # no same-file check, so aliased paths (same path or
-                    # a symlink to the source) would destroy the source;
-                    # shell cp refuses them instead. Hardlink aliases
-                    # cannot be detected over SFTP (no inode in attrs).
-                    src, dst = await asyncio.gather(
-                        channel.realpath(lpath), channel.realpath(rpath)
-                    )
-                    if src == dst:
-                        raise shutil.SameFileError(
-                            f"{lpath!r} and {rpath!r} are the same file"
+                    # The remote copy handles only the plain
+                    # file-to-file form. A directory destination means
+                    # "copy into" with cp's resolution rules (including
+                    # its same-file protections), so that form is
+                    # delegated to the shell fallback below.
+                    dst_attrs = None
+                    with suppress(SFTPNoSuchFile):
+                        dst_attrs = await channel.stat(rpath)
+                    if dst_attrs is None or not stat.S_ISDIR(
+                        dst_attrs.permissions
+                    ):
+                        # asyncssh opens the destination with truncation
+                        # and no same-file check, so aliased paths (same
+                        # path or a symlink to the source) would destroy
+                        # the source; shell cp refuses them instead.
+                        # Hardlink aliases cannot be detected over SFTP
+                        # (no inode in attrs).
+                        src, dst = await asyncio.gather(
+                            channel.realpath(lpath),
+                            channel.realpath(rpath),
                         )
-                    # preserve and follow_symlinks match what the shell
-                    # cp fallback does: copy the link target's content
-                    # and keep the source permissions.
-                    return await channel.copy(
-                        lpath,
-                        rpath,
-                        preserve=True,
-                        follow_symlinks=True,
-                        remote_only=True,
-                    )
+                        if src == dst:
+                            raise shutil.SameFileError(
+                                f"{lpath!r} and {rpath!r} " "are the same file"
+                            )
+                        # preserve and follow_symlinks match what the
+                        # shell cp fallback does: copy the link
+                        # target's content and keep the source
+                        # permissions.
+                        return await channel.copy(
+                            lpath,
+                            rpath,
+                            preserve=True,
+                            follow_symlinks=True,
+                            remote_only=True,
+                        )
 
         cmd = f"cp {shlex.quote(lpath)} {shlex.quote(rpath)}"
         await self._execute(cmd)

--- a/sshfs/spec.py
+++ b/sshfs/spec.py
@@ -218,15 +218,23 @@ class SSHFileSystem(AsyncFileSystem):
     @wrap_exceptions
     async def _mv(self, lpath, rpath, **kwargs):
         async with self._pool.get() as channel:
+            # posix-rename is an extension to the original SFTP
+            # protocol, but it is the only form that can replace an
+            # existing destination atomically.
             with suppress(SFTPOpUnsupported):
                 return await channel.posix_rename(lpath, rpath)
 
-        # Some systems doesn't natively support posix_rename
-        # which is an extension to the original SFTP protocol.
-        # In that case we are going to copy the file and delete
-        # it. The source must only be removed after the copy fully
-        # succeeded.
+            # The standard rename is still a rename: it keeps the
+            # object's identity (symlinks stay symlinks, hardlinks keep
+            # their inode and their special bits) and cannot lose data.
+            # It refuses an existing destination, which is the case the
+            # copy below has to handle.
+            with suppress(OSError, SFTPError):
+                return await channel.rename(lpath, rpath)
 
+        # Neither rename is available for these operands, so fall back
+        # to copying and removing. The source must only be removed
+        # after the copy fully succeeded.
         await self._cp_file(lpath, rpath)
         await self._rm_file(lpath)
 
@@ -314,17 +322,23 @@ class SSHFileSystem(AsyncFileSystem):
         # that a missing source cannot leave an empty destination.
         src_file = await channel.open(lpath, "rb", block_size=0)
         try:
-            # Like cp for new files: special bits stripped, and the
-            # server applies its umask to the requested mode. A mode of
-            # 0 is a valid mode; a missing one -- or a server that
-            # denies fstat -- falls back to the server default.
-            attrs = asyncssh.SFTPAttrs()
+            # Like cp for new files: the source's mode without the
+            # special bits, which the server then filters through its
+            # umask. A mode of 0 is a valid mode, so only a genuinely
+            # missing one is replaced -- and it is replaced with 0600,
+            # never with the server's default: servers may deny fstat
+            # (OpenSSH -P fstat) while allowing the copy, and defaulting
+            # to a world-readable mode would publish the contents of a
+            # private source. Owner-write is always requested so that
+            # the shell fallback can still write the file if the copy
+            # is denied; a source without owner-write therefore gains
+            # that single bit.
+            mode = 0o600
             with suppress(OSError, SFTPError):
                 src_attrs = await src_file.stat()
                 if src_attrs.permissions is not None:
-                    attrs = asyncssh.SFTPAttrs(
-                        permissions=src_attrs.permissions & 0o777
-                    )
+                    mode = (src_attrs.permissions & 0o777) | 0o200
+            attrs = asyncssh.SFTPAttrs(permissions=mode)
             try:
                 dst_file = await channel.open(
                     rpath,
@@ -342,12 +356,19 @@ class SSHFileSystem(AsyncFileSystem):
 
             try:
                 await channel.remote_copy(src_file, dst_file)
-            except (SFTPOpUnsupported, SFTPPermissionDenied):
-                # Advertised but denied (e.g. an OpenSSH allow/deny
-                # policy): stop trying the extension on this connection
-                # and let the shell cp overwrite the empty file just
-                # created.
+            except SFTPOpUnsupported:
+                # Advertised but not actually implemented: stop trying
+                # the extension on this connection and let the shell cp
+                # overwrite the empty file just created.
                 self._supports_remote_copy = False
+                with suppress(OSError, SFTPError):
+                    await dst_file.close()
+                return False
+            except SFTPPermissionDenied:
+                # Denied for these operands (an OpenSSH allow/deny
+                # policy can depend on the paths involved), which says
+                # nothing about the next copy: fall back for this one
+                # without disabling the extension connection-wide.
                 with suppress(OSError, SFTPError):
                     await dst_file.close()
                 return False
@@ -385,7 +406,9 @@ class SSHFileSystem(AsyncFileSystem):
                     return
 
         lpath, rpath = self._shell_paths(lpath, rpath)
-        cmd = f"cp {shlex.quote(lpath)} {shlex.quote(rpath)}"
+        # `--` keeps a relative path starting with a dash from being
+        # parsed as an option.
+        cmd = f"cp -- {shlex.quote(lpath)} {shlex.quote(rpath)}"
         await self._execute(cmd)
 
     @wrap_exceptions

--- a/sshfs/utils.py
+++ b/sshfs/utils.py
@@ -4,7 +4,7 @@ import os
 
 from asyncssh import ProcessError
 from asyncssh.misc import PermissionDenied
-from asyncssh.sftp import SFTPFailure, SFTPNoSuchFile
+from asyncssh.sftp import SFTPFailure, SFTPNoSuchFile, SFTPPermissionDenied
 from fsspec.asyn import sync_wrapper
 
 _NOT_FOUND = os.strerror(errno.ENOENT)
@@ -27,6 +27,8 @@ def wrap_exceptions(func):
             return await func(*args, **kwargs)
         except PermissionDenied as exc:
             raise PermissionError(exc.reason) from exc
+        except SFTPPermissionDenied as exc:
+            raise PermissionError(errno.EACCES, exc.reason) from exc
         except SFTPNoSuchFile as exc:
             raise FileNotFoundError(errno.ENOENT, _NOT_FOUND) from exc
         except ProcessError as exc:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,13 +23,28 @@ class _TestSSHServer(asyncssh.SSHServer):
         return key == _USER_KEY.convert_to_public()
 
 
-@pytest.fixture(scope="session")
-def asyncssh_server(tmp_path_factory):
-    """SFTP server that, unlike the paramiko-based mockssh fixture,
-    implements the copy-data and limits extensions. Authenticated with
-    the test user key and chrooted to a fresh directory; yields
-    (host, port, root) where the remote "/" maps to root."""
-    root = tmp_path_factory.mktemp("asyncssh-root")
+class _ZeroSizeSFTPServer(asyncssh.SFTPServer):
+    """Reports every file as empty, like procfs and sysfs do, while
+    still serving the real content."""
+
+    def _zero(self, result):
+        attrs = asyncssh.SFTPAttrs.from_local(result)
+        attrs.size = 0
+        return attrs
+
+    def stat(self, path):
+        return self._zero(super().stat(path))
+
+    def lstat(self, path):
+        return self._zero(super().lstat(path))
+
+    def fstat(self, file_obj):
+        return self._zero(super().fstat(file_obj))
+
+
+def _serve(root, sftp_server=asyncssh.SFTPServer):
+    """Start an authenticated SFTP server chrooted to `root` on its own
+    event loop thread. Yields (host, port, root)."""
     loop = asyncio.new_event_loop()
     thread = threading.Thread(target=loop.run_forever, daemon=True)
     thread.start()
@@ -40,9 +55,7 @@ def asyncssh_server(tmp_path_factory):
             0,
             server_host_keys=[_USER_KEY],
             server_factory=_TestSSHServer,
-            sftp_factory=lambda chan: asyncssh.SFTPServer(
-                chan, chroot=str(root)
-            ),
+            sftp_factory=lambda chan: sftp_server(chan, chroot=str(root)),
         )
 
     server = asyncio.run_coroutine_threadsafe(_listen(), loop).result(30)
@@ -68,6 +81,23 @@ def asyncssh_server(tmp_path_factory):
         loop.call_soon_threadsafe(loop.stop)
         thread.join(timeout=5)
         loop.close()
+
+
+@pytest.fixture(scope="session")
+def asyncssh_server(tmp_path_factory):
+    """SFTP server that, unlike the paramiko-based mockssh fixture,
+    implements the copy-data and limits extensions. Authenticated with
+    the test user key and chrooted to a fresh directory; yields
+    (host, port, root) where the remote "/" maps to root."""
+    yield from _serve(tmp_path_factory.mktemp("asyncssh-root"))
+
+
+@pytest.fixture(scope="session")
+def zero_size_server(tmp_path_factory):
+    """Like asyncssh_server, but every stat reports size 0."""
+    yield from _serve(
+        tmp_path_factory.mktemp("zero-size-root"), _ZeroSizeSFTPServer
+    )
 
 
 def _handler_run(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,45 @@
+import asyncio
 import threading
+from pathlib import Path
 from queue import Queue
 
+import asyncssh
 import mockssh.server
+import pytest
+
+_STATIC = (Path(__file__).parent / "static").resolve()
+
+
+class _NoAuthSSHServer(asyncssh.SSHServer):
+    def begin_auth(self, username):
+        return False
+
+
+@pytest.fixture(scope="session")
+def asyncssh_server():
+    """SFTP server that, unlike the paramiko-based mockssh fixture,
+    implements the copy-data and limits extensions. Serves the local
+    filesystem as the current user; yields (host, port)."""
+    loop = asyncio.new_event_loop()
+    thread = threading.Thread(target=loop.run_forever, daemon=True)
+    thread.start()
+
+    async def _listen():
+        return await asyncssh.listen(
+            "127.0.0.1",
+            0,
+            server_host_keys=[str(_STATIC / "user.key")],
+            server_factory=_NoAuthSSHServer,
+            sftp_factory=asyncssh.SFTPServer,
+        )
+
+    server = asyncio.run_coroutine_threadsafe(_listen(), loop).result(30)
+    try:
+        yield "127.0.0.1", server.get_port()
+    finally:
+        loop.call_soon_threadsafe(server.close)
+        loop.call_soon_threadsafe(loop.stop)
+        thread.join(timeout=5)
 
 
 def _handler_run(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import asyncio
 import threading
+from contextlib import suppress
 from pathlib import Path
 from queue import Queue
 
@@ -8,18 +9,27 @@ import mockssh.server
 import pytest
 
 _STATIC = (Path(__file__).parent / "static").resolve()
+_USER_KEY = asyncssh.read_private_key(str(_STATIC / "user.key"))
 
 
-class _NoAuthSSHServer(asyncssh.SSHServer):
+class _TestSSHServer(asyncssh.SSHServer):
     def begin_auth(self, username):
-        return False
+        return True
+
+    def public_key_auth_supported(self):
+        return True
+
+    def validate_public_key(self, username, key):
+        return key == _USER_KEY.convert_to_public()
 
 
 @pytest.fixture(scope="session")
-def asyncssh_server():
+def asyncssh_server(tmp_path_factory):
     """SFTP server that, unlike the paramiko-based mockssh fixture,
-    implements the copy-data and limits extensions. Serves the local
-    filesystem as the current user; yields (host, port)."""
+    implements the copy-data and limits extensions. Authenticated with
+    the test user key and chrooted to a fresh directory; yields
+    (host, port, root) where the remote "/" maps to root."""
+    root = tmp_path_factory.mktemp("asyncssh-root")
     loop = asyncio.new_event_loop()
     thread = threading.Thread(target=loop.run_forever, daemon=True)
     thread.start()
@@ -28,18 +38,36 @@ def asyncssh_server():
         return await asyncssh.listen(
             "127.0.0.1",
             0,
-            server_host_keys=[str(_STATIC / "user.key")],
-            server_factory=_NoAuthSSHServer,
-            sftp_factory=asyncssh.SFTPServer,
+            server_host_keys=[_USER_KEY],
+            server_factory=_TestSSHServer,
+            sftp_factory=lambda chan: asyncssh.SFTPServer(
+                chan, chroot=str(root)
+            ),
         )
 
     server = asyncio.run_coroutine_threadsafe(_listen(), loop).result(30)
     try:
-        yield "127.0.0.1", server.get_port()
+        yield "127.0.0.1", server.get_port(), root
     finally:
-        loop.call_soon_threadsafe(server.close)
+
+        async def _shutdown():
+            server.close()
+            await server.wait_closed()
+            tasks = [
+                task
+                for task in asyncio.all_tasks()
+                if task is not asyncio.current_task()
+            ]
+            for task in tasks:
+                task.cancel()
+            if tasks:
+                await asyncio.wait(tasks, timeout=5)
+
+        with suppress(Exception):
+            asyncio.run_coroutine_threadsafe(_shutdown(), loop).result(30)
         loop.call_soon_threadsafe(loop.stop)
         thread.join(timeout=5)
+        loop.close()
 
 
 def _handler_run(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,9 +42,11 @@ class _ZeroSizeSFTPServer(asyncssh.SFTPServer):
         return self._zero(super().fstat(file_obj))
 
 
-def _serve(root, sftp_server=asyncssh.SFTPServer):
+def _serve(root, sftp_server=asyncssh.SFTPServer, sftp_version=3):
     """Start an authenticated SFTP server chrooted to `root` on its own
-    event loop thread. Yields (host, port, root)."""
+    event loop thread. Yields (host, port, root, sftp_version)."""
+    if not hasattr(asyncssh.SFTPClient, "supports_remote_copy"):
+        pytest.skip("asyncssh without copy-data support (< 2.19)")
     loop = asyncio.new_event_loop()
     thread = threading.Thread(target=loop.run_forever, daemon=True)
     thread.start()
@@ -56,11 +58,12 @@ def _serve(root, sftp_server=asyncssh.SFTPServer):
             server_host_keys=[_USER_KEY],
             server_factory=_TestSSHServer,
             sftp_factory=lambda chan: sftp_server(chan, chroot=str(root)),
+            sftp_version=sftp_version,
         )
 
     server = asyncio.run_coroutine_threadsafe(_listen(), loop).result(30)
     try:
-        yield "127.0.0.1", server.get_port(), root
+        yield "127.0.0.1", server.get_port(), root, sftp_version
     finally:
 
         async def _shutdown():
@@ -83,13 +86,19 @@ def _serve(root, sftp_server=asyncssh.SFTPServer):
         loop.close()
 
 
-@pytest.fixture(scope="session")
-def asyncssh_server(tmp_path_factory):
+@pytest.fixture(scope="session", params=[3, 4], ids=["sftpv3", "sftpv4"])
+def asyncssh_server(tmp_path_factory, request):
     """SFTP server that, unlike the paramiko-based mockssh fixture,
     implements the copy-data and limits extensions. Authenticated with
     the test user key and chrooted to a fresh directory; yields
-    (host, port, root) where the remote "/" maps to root."""
-    yield from _serve(tmp_path_factory.mktemp("asyncssh-root"))
+    (host, port, root, version) where the remote "/" maps to root.
+    Runs once per
+    SFTP protocol generation: v4+ moves the file type out of the
+    permission bits."""
+    yield from _serve(
+        tmp_path_factory.mktemp(f"asyncssh-root-v{request.param}"),
+        sftp_version=request.param,
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -242,14 +242,20 @@ class _FakeChannelPool:
         return _Ctx()
 
 
-@pytest.fixture(scope="session")
-def copydata_fs(asyncssh_server):
+@pytest.fixture(scope="session", params=[None, 4], ids=["sftpv3", "sftpv4"])
+def copydata_fs(asyncssh_server, request):
+    # v4+ separates the file type from `permissions`, so both protocol
+    # generations must satisfy the same contract.
     host, port, _root = asyncssh_server
+    extra = {}
+    if request.param is not None:
+        extra["sftp_client_kwargs"] = {"sftp_version": request.param}
     fs = SSHFileSystem(
         host=host,
         port=port,
         username="user",
         client_keys=[USERS["user"]],
+        **extra,
     )
     yield fs
     # Close the connection so the server fixture can shut its loop
@@ -348,10 +354,24 @@ def test_cp_file_copy_data_never_redirects(copydata_fs, copydata_dir):
     assert not (local / "missing").exists()
 
 
+def test_mv_hardlink_alias(copydata_fs, copydata_dir):
+    # POSIX rename between two names of the same inode is a no-op:
+    # the move succeeds with both names surviving and no data lost.
+    fs = copydata_fs
+    local, remote = copydata_dir
+    src = local / "src"
+    src.write_bytes(b"payload")
+    os.link(src, local / "hard")
+
+    fs.mv(remote + "/src", remote + "/hard")
+    assert src.read_bytes() == b"payload"
+    assert (local / "hard").read_bytes() == b"payload"
+
+
 def test_cp_file_copy_data_denied(fs, monkeypatch):
-    # copy-data advertised but denied by server policy: the created
-    # destination is removed, the capability is re-cached as
-    # unsupported, and the copy falls back to the shell.
+    # copy-data advertised but denied by server policy: the capability
+    # is re-cached as unsupported and the copy falls back to the shell,
+    # which overwrites the empty file created by the exclusive open.
     events = []
 
     class _File:
@@ -393,9 +413,6 @@ def test_cp_file_copy_data_denied(fs, monkeypatch):
         async def remote_copy(self, src, dst):
             raise SFTPPermissionDenied("denied by policy")
 
-        async def remove(self, path):
-            events.append(("remove", path))
-
     async def record_shell(cmd, **kwargs):
         events.append(("shell", cmd))
 
@@ -404,7 +421,6 @@ def test_cp_file_copy_data_denied(fs, monkeypatch):
     monkeypatch.setattr(fs, "_execute", record_shell)
 
     fs.cp_file("/src", "/dst")
-    assert ("remove", "/dst") in events
     assert ("shell", "cp /src /dst") in events
     assert fs._supports_remote_copy is False
 

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -316,7 +316,11 @@ def test_cp_file_copy_data_ignores_reported_size(zero_size_server):
     # never sizes the destination from a stat snapshot.
     host, port, root, _version = zero_size_server
     fs = SSHFileSystem(
-        host=host, port=port, username="user", client_keys=[USERS["user"]]
+        host=host,
+        port=port,
+        username="user",
+        client_keys=[USERS["user"]],
+        skip_instance_cache=True,
     )
     try:
         name = secrets.token_hex(4)
@@ -335,8 +339,7 @@ def test_remote_copy_keeps_mode_zero(fs, monkeypatch):
     # A mode of 0 is a valid mode, not a missing one: it must be
     # carried over instead of falling back to the server's default
     # (SFTP v4+ reports it as permissions == 0, since the file type
-    # lives in a separate field). Only owner-write is added, so no
-    # group or other bit appears.
+    # lives in a separate field).
     opened = []
 
     class _File:
@@ -367,7 +370,7 @@ def test_remote_copy_keeps_mode_zero(fs, monkeypatch):
 
     fs.cp_file("/src", "/dst")
     _dst_path, dst_args = opened[-1]
-    assert dst_args[1].permissions == 0o200
+    assert dst_args[1].permissions == 0
 
 
 @requires_copy_data
@@ -447,10 +450,31 @@ def test_copydata_server_negotiates_expected_version(
 
 
 @requires_copy_data
-def test_cp_file_copy_data_unreadable_source_mode(copydata_fs, copydata_dir):
-    # A source without owner-write keeps its group/other bits and
-    # gains only owner-write, so the shell fallback could still write
-    # the file if the copy were denied.
+def test_info_reports_type_on_every_version(copydata_fs, copydata_dir):
+    # SFTP v4+ reports the file type in its own field and leaves only
+    # the permission bits in `permissions`, so the type must not be
+    # decoded from the mode alone.
+    fs = copydata_fs
+    local, remote = copydata_dir
+    (local / "file").write_bytes(b"payload")
+    (local / "dir").mkdir()
+    (local / "link").symlink_to("file")
+
+    assert fs.info(remote + "/file")["type"] == "file"
+    assert fs.info(remote + "/dir")["type"] == "directory"
+    assert fs.isdir(remote + "/dir")
+    assert fs.isfile(remote + "/file")
+    assert {i["type"] for i in fs.ls(remote)} == {
+        "file",
+        "directory",
+        "link",
+    }
+
+
+@requires_copy_data
+def test_cp_file_copy_data_read_only_source_mode(copydata_fs, copydata_dir):
+    # A read-only source keeps its exact mode, like cp: the copy must
+    # not widen it just because the extension was used.
     fs = copydata_fs
     local, remote = copydata_dir
     (local / "src").write_bytes(b"payload")
@@ -458,7 +482,7 @@ def test_cp_file_copy_data_unreadable_source_mode(copydata_fs, copydata_dir):
 
     fs.cp_file(remote + "/src", remote + "/dst")
     assert (local / "dst").read_bytes() == b"payload"
-    assert ((local / "dst").stat().st_mode & 0o077) == 0
+    assert ((local / "dst").stat().st_mode & 0o7777) == 0o400
 
 
 @requires_copy_data
@@ -613,9 +637,13 @@ def test_cp_file_copy_data_denied(fs, monkeypatch):
     assert fs._supports_remote_copy is False
 
 
-def test_mv_fallback_keeps_source_on_copy_failure(fs, monkeypatch):
-    # When posix_rename is unsupported and the copy fails, the source
-    # must survive: it may only be removed after a successful copy.
+def test_mv_falls_back_to_remote_mv(fs, monkeypatch):
+    # When neither rename applies, the move is handed to the remote mv
+    # rather than copied and deleted: a copy only proves that bytes
+    # reached an open handle, so deleting the source afterwards could
+    # destroy the only remaining copy of the data.
+    events = []
+
     class Channel:
         async def posix_rename(self, lpath, rpath):
             raise SFTPOpUnsupported("posix-rename not supported")
@@ -623,28 +651,42 @@ def test_mv_fallback_keeps_source_on_copy_failure(fs, monkeypatch):
         async def rename(self, lpath, rpath):
             raise SFTPFailure("destination exists")
 
-    removed = []
+    async def fail_cp(*args, **kwargs):
+        raise AssertionError("mv must not copy and delete")
 
-    async def failing_cp(*args, **kwargs):
-        raise OSError("copy failed")
+    async def fail_rm(*args, **kwargs):
+        raise AssertionError("mv must not remove the source itself")
 
-    async def record_rm(path, **kwargs):
-        removed.append(path)
+    async def record_shell(cmd, **kwargs):
+        events.append(cmd)
 
     monkeypatch.setattr(fs, "_pool", _FakeChannelPool(Channel()))
-    monkeypatch.setattr(fs, "_cp_file", failing_cp)
-    monkeypatch.setattr(fs, "_rm_file", record_rm)
+    monkeypatch.setattr(fs, "_cp_file", fail_cp)
+    monkeypatch.setattr(fs, "_rm_file", fail_rm)
+    monkeypatch.setattr(fs, "_execute", record_shell)
 
-    with pytest.raises(OSError):
-        fs.mv("/src", "/dst")
-    assert removed == []
-
-    async def ok_cp(*args, **kwargs):
-        pass
-
-    monkeypatch.setattr(fs, "_cp_file", ok_cp)
     fs.mv("/src", "/dst")
-    assert removed == ["/src"]
+    assert events == ["mv -- /src /dst"]
+
+
+def test_mv_propagates_rename_errors(fs, monkeypatch):
+    # A denied rename is an answer, not a reason to try something with
+    # different semantics.
+    class Channel:
+        async def posix_rename(self, lpath, rpath):
+            raise SFTPOpUnsupported("posix-rename not supported")
+
+        async def rename(self, lpath, rpath):
+            raise SFTPPermissionDenied("rename denied by policy")
+
+    async def fail_shell(*args, **kwargs):
+        raise AssertionError("a denied rename must not reach the shell")
+
+    monkeypatch.setattr(fs, "_pool", _FakeChannelPool(Channel()))
+    monkeypatch.setattr(fs, "_execute", fail_shell)
+
+    with pytest.raises(PermissionError):
+        fs.mv("/src", "/dst")
 
 
 @pytest.mark.parametrize("legacy_asyncssh", [False, True])

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -9,6 +9,7 @@ from contextlib import suppress
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
+from unittest import mock
 
 import fsspec
 import pytest
@@ -79,6 +80,11 @@ def fs_hard_queue(ssh_server, user="user"):
         client_keys=[USERS[user]],
         pool_type=SFTPHardChannelPool,
     )
+
+
+async def _channel_version(fs):
+    async with fs._pool.get() as channel:
+        return channel.version
 
 
 def strip_keys(info):
@@ -242,20 +248,17 @@ class _FakeChannelPool:
         return _Ctx()
 
 
-@pytest.fixture(scope="session", params=[None, 4], ids=["sftpv3", "sftpv4"])
-def copydata_fs(asyncssh_server, request):
-    # v4+ separates the file type from `permissions`, so both protocol
-    # generations must satisfy the same contract.
-    host, port, _root = asyncssh_server
-    extra = {}
-    if request.param is not None:
-        extra["sftp_client_kwargs"] = {"sftp_version": request.param}
+@pytest.fixture(scope="session")
+def copydata_fs(asyncssh_server):
+    # The server fixture runs the whole suite once per SFTP protocol
+    # generation; the client negotiates up to whatever it offers.
+    host, port, _root, version = asyncssh_server
     fs = SSHFileSystem(
         host=host,
         port=port,
         username="user",
         client_keys=[USERS["user"]],
-        **extra,
+        sftp_client_kwargs={"sftp_version": version},
     )
     yield fs
     # Close the connection so the server fixture can shut its loop
@@ -266,7 +269,7 @@ def copydata_fs(asyncssh_server, request):
 
 @pytest.fixture
 def copydata_dir(asyncssh_server, request):
-    _host, _port, root = asyncssh_server
+    _host, _port, root, _version = asyncssh_server
     # unique per invocation so pytest-rerunfailures retries get a
     # fresh directory
     local = root / f"{request.node.name}-{secrets.token_hex(4)}"
@@ -311,17 +314,18 @@ def test_cp_file_copy_data_ignores_reported_size(zero_size_server):
     # Sources whose stat lies about the size (procfs, sysfs) must be
     # copied whole: the copy runs to the source's real end of file and
     # never sizes the destination from a stat snapshot.
-    host, port, root = zero_size_server
+    host, port, root, _version = zero_size_server
     fs = SSHFileSystem(
         host=host, port=port, username="user", client_keys=[USERS["user"]]
     )
     try:
-        (root / "src").write_bytes(b"payload" * 1000)
-        assert fs.info("/src")["size"] == 0
+        name = secrets.token_hex(4)
+        (root / f"src-{name}").write_bytes(b"payload" * 1000)
+        assert fs.info(f"/src-{name}")["size"] == 0
 
-        fs.cp_file("/src", "/dst")
+        fs.cp_file(f"/src-{name}", f"/dst-{name}")
         assert fs._supports_remote_copy is True
-        assert (root / "dst").read_bytes() == b"payload" * 1000
+        assert (root / f"dst-{name}").read_bytes() == b"payload" * 1000
     finally:
         with suppress(Exception):
             sync(fs.loop, fs._stack.aclose, timeout=5)
@@ -329,9 +333,10 @@ def test_cp_file_copy_data_ignores_reported_size(zero_size_server):
 
 def test_remote_copy_keeps_mode_zero(fs, monkeypatch):
     # A mode of 0 is a valid mode, not a missing one: it must be
-    # requested as-is instead of falling back to the server's default
+    # carried over instead of falling back to the server's default
     # (SFTP v4+ reports it as permissions == 0, since the file type
-    # lives in a separate field).
+    # lives in a separate field). Only owner-write is added, so no
+    # group or other bit appears.
     opened = []
 
     class _File:
@@ -362,7 +367,7 @@ def test_remote_copy_keeps_mode_zero(fs, monkeypatch):
 
     fs.cp_file("/src", "/dst")
     _dst_path, dst_args = opened[-1]
-    assert dst_args[1].permissions == 0
+    assert dst_args[1].permissions == 0o200
 
 
 @requires_copy_data
@@ -413,6 +418,7 @@ def test_cp_file_copy_data_never_redirects(copydata_fs, copydata_dir):
     assert not (local / "missing").exists()
 
 
+@requires_copy_data
 def test_mv_hardlink_alias(copydata_fs, copydata_dir):
     # POSIX rename between two names of the same inode is a no-op:
     # the move succeeds with both names surviving and no data lost.
@@ -427,9 +433,132 @@ def test_mv_hardlink_alias(copydata_fs, copydata_dir):
     assert (local / "hard").read_bytes() == b"payload"
 
 
+@requires_copy_data
+def test_copydata_server_negotiates_expected_version(
+    copydata_fs, asyncssh_server
+):
+    # The functional suite claims to cover both protocol generations,
+    # so the negotiated version must actually be the server's.
+    _host, _port, _root, version = asyncssh_server
+    negotiated = sync(
+        copydata_fs.loop, _channel_version, copydata_fs, timeout=10
+    )
+    assert negotiated == version
+
+
+@requires_copy_data
+def test_cp_file_copy_data_unreadable_source_mode(copydata_fs, copydata_dir):
+    # A source without owner-write keeps its group/other bits and
+    # gains only owner-write, so the shell fallback could still write
+    # the file if the copy were denied.
+    fs = copydata_fs
+    local, remote = copydata_dir
+    (local / "src").write_bytes(b"payload")
+    (local / "src").chmod(0o400)
+
+    fs.cp_file(remote + "/src", remote + "/dst")
+    assert (local / "dst").read_bytes() == b"payload"
+    assert ((local / "dst").stat().st_mode & 0o077) == 0
+
+
+@requires_copy_data
+def test_mv_uses_standard_rename(copydata_fs, copydata_dir):
+    # Without posix-rename, a plain rename still keeps the object's
+    # identity: a symlink must stay a symlink instead of being
+    # flattened into a copy of its target.
+    fs = copydata_fs
+    local, remote = copydata_dir
+    (local / "target").write_bytes(b"payload")
+    (local / "link").symlink_to("target")
+
+    async def _no_posix_rename(*args, **kwargs):
+        raise SFTPOpUnsupported("posix-rename not supported")
+
+    with mock.patch.object(SFTPClient, "posix_rename", _no_posix_rename):
+        fs.mv(remote + "/link", remote + "/moved")
+
+    assert (local / "moved").is_symlink()
+    assert os.readlink(local / "moved") == "target"
+
+
+def test_remote_copy_unknown_mode_is_private(fs, monkeypatch):
+    # A server that denies fstat must not cause the destination to be
+    # created with the server's default (world-readable) mode.
+    opened = []
+
+    class _File:
+        async def stat(self):
+            raise SFTPPermissionDenied("fstat denied")
+
+        async def close(self):
+            pass
+
+    class Channel:
+        supports_remote_copy = True
+
+        def encode(self, path):
+            return path.encode() if isinstance(path, str) else path
+
+        async def isdir(self, path):
+            return False
+
+        async def open(self, path, *args, **kwargs):
+            opened.append((path, args))
+            return _File()
+
+        async def remote_copy(self, src, dst):
+            pass
+
+    monkeypatch.setattr(fs, "_supports_remote_copy", True)
+    monkeypatch.setattr(fs, "_pool", _FakeChannelPool(Channel()))
+
+    fs.cp_file("/src", "/dst")
+    _path, args = opened[-1]
+    assert args[1].permissions == 0o600
+
+
+def test_cp_file_copy_data_denied_is_not_cached(fs, monkeypatch):
+    # A denial can depend on the operands, so it must not disable the
+    # extension for every later copy on the connection.
+    events = []
+
+    class _File:
+        async def stat(self):
+            return SFTPAttrs(permissions=0o100644)
+
+        async def close(self):
+            pass
+
+    class Channel:
+        supports_remote_copy = True
+
+        def encode(self, path):
+            return path.encode() if isinstance(path, str) else path
+
+        async def isdir(self, path):
+            return False
+
+        async def open(self, path, *args, **kwargs):
+            return _File()
+
+        async def remote_copy(self, src, dst):
+            raise SFTPPermissionDenied("denied for these operands")
+
+    async def record_shell(cmd, **kwargs):
+        events.append(cmd)
+
+    monkeypatch.setattr(fs, "_supports_remote_copy", None)
+    monkeypatch.setattr(fs, "_pool", _FakeChannelPool(Channel()))
+    monkeypatch.setattr(fs, "_execute", record_shell)
+
+    fs.cp_file("/denied", "/dst")
+    assert events == ["cp -- /denied /dst"]
+    assert fs._supports_remote_copy is True
+
+
 def test_cp_file_copy_data_denied(fs, monkeypatch):
-    # copy-data advertised but denied by server policy: the capability
-    # is re-cached as unsupported and the copy falls back to the shell,
+    # copy-data advertised but not implemented: the capability is
+    # re-cached as unsupported and the copy falls back to the shell,
     # which overwrites the empty file created by the exclusive open.
     events = []
 
@@ -470,7 +599,7 @@ def test_cp_file_copy_data_denied(fs, monkeypatch):
             return _OpenResult()
 
         async def remote_copy(self, src, dst):
-            raise SFTPPermissionDenied("denied by policy")
+            raise SFTPOpUnsupported("advertised but not implemented")
 
     async def record_shell(cmd, **kwargs):
         events.append(("shell", cmd))
@@ -480,7 +609,7 @@ def test_cp_file_copy_data_denied(fs, monkeypatch):
     monkeypatch.setattr(fs, "_execute", record_shell)
 
     fs.cp_file("/src", "/dst")
-    assert ("shell", "cp /src /dst") in events
+    assert ("shell", "cp -- /src /dst") in events
     assert fs._supports_remote_copy is False
 
 
@@ -490,6 +619,9 @@ def test_mv_fallback_keeps_source_on_copy_failure(fs, monkeypatch):
     class Channel:
         async def posix_rename(self, lpath, rpath):
             raise SFTPOpUnsupported("posix-rename not supported")
+
+        async def rename(self, lpath, rpath):
+            raise SFTPFailure("destination exists")
 
     removed = []
 
@@ -544,7 +676,7 @@ def test_cp_file_shell_fallback(fs, monkeypatch, legacy_asyncssh):
 
     fs.cp_file("/src", "/dst")
     fs.cp_file("/src2", "/dst2")
-    assert calls == ["cp /src /dst", "cp /src2 /dst2"]
+    assert calls == ["cp -- /src /dst", "cp -- /src2 /dst2"]
     assert len(pool_uses) == 1
 
 

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -2,7 +2,6 @@ import hashlib
 import os
 import posixpath
 import secrets
-import shutil
 import tempfile
 import warnings
 from concurrent import futures
@@ -13,7 +12,14 @@ from types import SimpleNamespace
 
 import fsspec
 import pytest
-from asyncssh.sftp import SFTPAttrs, SFTPError, SFTPFailure, SFTPOpUnsupported
+from asyncssh.misc import ChannelOpenError
+from asyncssh.sftp import (
+    SFTPAttrs,
+    SFTPClient,
+    SFTPFailure,
+    SFTPOpUnsupported,
+    SFTPPermissionDenied,
+)
 from fsspec.asyn import sync
 from importlib_metadata import entry_points
 
@@ -255,14 +261,23 @@ def copydata_fs(asyncssh_server):
 @pytest.fixture
 def copydata_dir(asyncssh_server, request):
     _host, _port, root = asyncssh_server
-    local = root / request.node.name
+    # unique per invocation so pytest-rerunfailures retries get a
+    # fresh directory
+    local = root / f"{request.node.name}-{secrets.token_hex(4)}"
     local.mkdir()
     # the server is chrooted to `root`, so `local` is served as this
     # remote path
     yield local, "/" + local.name
 
 
-def test_cp_file_copy_data(copydata_fs, copydata_dir):
+requires_copy_data = pytest.mark.skipif(
+    not hasattr(SFTPClient, "supports_remote_copy"),
+    reason="asyncssh without copy-data support (< 2.19)",
+)
+
+
+@requires_copy_data
+def test_cp_file_copy_data_creates(copydata_fs, copydata_dir):
     fs = copydata_fs
     local, remote = copydata_dir
     (local / "src").write_bytes(b"payload")
@@ -279,78 +294,119 @@ def test_cp_file_copy_data(copydata_fs, copydata_dir):
     # umask, like cp
     assert ((local / "dst").stat().st_mode & 0o7777) == 0o666 & ~umask
 
-    # an existing destination keeps its inode: its own mode survives
-    # and hardlink peers see the update, like cp writing through the
-    # file
-    (local / "dst").chmod(0o600)
-    os.link(local / "dst", local / "peer")
-    (local / "src").write_bytes(b"new payload")
-    fs.cp_file(remote + "/src", remote + "/dst")
-    assert (local / "dst").read_bytes() == b"new payload"
-    assert ((local / "dst").stat().st_mode & 0o7777) == 0o600
-    assert (local / "peer").read_bytes() == b"new payload"
+    # "copy into" an existing directory creates the source's basename
+    (local / "d").mkdir()
+    fs.cp_file(remote + "/src", remote + "/d")
+    assert (local / "d" / "src").read_bytes() == b"payload"
 
 
-def test_cp_file_copy_data_aliases(copydata_fs, copydata_dir):
+@requires_copy_data
+def test_cp_file_copy_data_existing_destinations(copydata_fs, copydata_dir):
+    # The extension path only creates destinations. Anything existing
+    # -- including every alias of the source -- is left to the shell
+    # fallback, which this server does not offer: the copy must fail
+    # without touching a single byte.
     fs = copydata_fs
     local, remote = copydata_dir
     src = local / "src"
     src.write_bytes(b"payload")
 
-    with pytest.raises(shutil.SameFileError):
-        fs.cp_file(remote + "/src", remote + "/src")
+    (local / "existing").write_bytes(b"old")
+    (local / "link").symlink_to("src")
+    os.link(src, local / "hard")
 
-    # bytes and str spellings of the same path are still aliases
-    with pytest.raises(shutil.SameFileError):
+    for dst in ["/src", "/existing", "/link", "/hard"]:
+        with pytest.raises((OSError, ChannelOpenError)):
+            fs.cp_file(remote + "/src", remote + dst)
+    with pytest.raises((OSError, ChannelOpenError)):
         fs.cp_file((remote + "/src").encode(), remote + "/src")
 
-    (local / "link").symlink_to("src")
-    with pytest.raises(shutil.SameFileError):
-        fs.cp_file(remote + "/src", remote + "/link")
-
-    # hardlink aliases cannot be detected over SFTP: the write-through
-    # copy puts the bytes over themselves and must leave the file,
-    # its content and the link intact
-    os.link(src, local / "hard")
-    fs.cp_file(remote + "/src", remote + "/hard")
     assert src.read_bytes() == b"payload"
+    assert (local / "existing").read_bytes() == b"old"
     assert (local / "hard").stat().st_ino == src.stat().st_ino
-
-
-def test_cp_file_copy_data_directory_destination(copydata_fs, copydata_dir):
-    fs = copydata_fs
-    local, remote = copydata_dir
-    (local / "src").write_bytes(b"payload")
+    # "copy into" resolving to an existing file is refused the same way
     (local / "d").mkdir()
-
-    fs.cp_file(remote + "/src", remote + "/d")
-    assert (local / "d" / "src").read_bytes() == b"payload"
-
-    # "copy into" resolving to the source itself is an alias
-    with pytest.raises(shutil.SameFileError):
-        fs.cp_file(remote + "/d/src", remote + "/d")
+    os.link(src, local / "d" / "src")
+    with pytest.raises((OSError, ChannelOpenError)):
+        fs.cp_file(remote + "/src", remote + "/d")
     assert (local / "d" / "src").read_bytes() == b"payload"
 
 
-def test_cp_file_copy_data_destination_errors(copydata_fs, copydata_dir):
+@requires_copy_data
+def test_cp_file_copy_data_never_redirects(copydata_fs, copydata_dir):
+    # FXF_EXCL refuses to create through a dangling symlink, so the
+    # copy cannot be redirected to the link's target. (Trailing-slash
+    # handling is the server's path resolution and is not asserted:
+    # this server normalizes it away, OpenSSH rejects it.)
     fs = copydata_fs
     local, remote = copydata_dir
     (local / "src").write_bytes(b"payload")
+    (local / "dangling").symlink_to("missing")
 
-    # a read-only destination is refused at open, like cp, and stays
-    # untouched
-    ro = local / "ro"
-    ro.write_bytes(b"old")
-    ro.chmod(0o444)
-    with pytest.raises(PermissionError):
-        fs.cp_file(remote + "/src", remote + "/ro")
-    assert ro.read_bytes() == b"old"
+    with pytest.raises((OSError, ChannelOpenError)):
+        fs.cp_file(remote + "/src", remote + "/dangling")
+    assert not (local / "missing").exists()
 
-    # a trailing slash on a file destination is not a directory (the
-    # server rejects it; like mkdir, the SFTP error is passed through)
-    with pytest.raises((OSError, SFTPError)):
-        fs.cp_file(remote + "/src", remote + "/ro/")
-    assert ro.read_bytes() == b"old"
+
+def test_cp_file_copy_data_denied(fs, monkeypatch):
+    # copy-data advertised but denied by server policy: the created
+    # destination is removed, the capability is re-cached as
+    # unsupported, and the copy falls back to the shell.
+    events = []
+
+    class _File:
+        async def stat(self):
+            return SFTPAttrs(permissions=0o100644)
+
+        async def close(self):
+            events.append("close")
+
+    class _OpenResult:
+        def __init__(self):
+            self.file = _File()
+
+        def __await__(self):
+            async def _result():
+                return self.file
+
+            return _result().__await__()
+
+        async def __aenter__(self):
+            return self.file
+
+        async def __aexit__(self, *exc):
+            return False
+
+    class Channel:
+        supports_remote_copy = True
+
+        def encode(self, path):
+            return path.encode() if isinstance(path, str) else path
+
+        async def isdir(self, path):
+            return False
+
+        def open(self, path, *args, **kwargs):
+            events.append(("open", path))
+            return _OpenResult()
+
+        async def remote_copy(self, src, dst):
+            raise SFTPPermissionDenied("denied by policy")
+
+        async def remove(self, path):
+            events.append(("remove", path))
+
+    async def record_shell(cmd, **kwargs):
+        events.append(("shell", cmd))
+
+    monkeypatch.setattr(fs, "_supports_remote_copy", None)
+    monkeypatch.setattr(fs, "_pool", _FakeChannelPool(Channel()))
+    monkeypatch.setattr(fs, "_execute", record_shell)
+
+    fs.cp_file("/src", "/dst")
+    assert ("remove", "/dst") in events
+    assert ("shell", "cp /src /dst") in events
+    assert fs._supports_remote_copy is False
 
 
 def test_mv_fallback_keeps_source_on_copy_failure(fs, monkeypatch):

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -1,4 +1,5 @@
 import hashlib
+import os
 import posixpath
 import secrets
 import shutil
@@ -11,7 +12,7 @@ from types import SimpleNamespace
 
 import fsspec
 import pytest
-from asyncssh.sftp import SFTPAttrs, SFTPFailure, SFTPNoSuchFile
+from asyncssh.sftp import SFTPAttrs, SFTPFailure, SFTPOpUnsupported
 from importlib_metadata import entry_points
 
 from sshfs import SSHFileSystem
@@ -75,6 +76,7 @@ def fs_hard_queue(ssh_server, user="user"):
 def strip_keys(info):
     for key in ["name", "time", "mtime", "atime"]:
         info.pop(key, None)
+    return info
 
 
 def test_fsspec_registration(ssh_server):
@@ -232,101 +234,104 @@ class _FakeChannelPool:
         return _Ctx()
 
 
-def test_cp_file_remote_copy(fs, monkeypatch):
-    # A channel advertising copy-data must be used with remote_only=True
-    # (otherwise asyncssh silently copies through the client), matching
-    # the shell fallback's semantics (content of the link target,
-    # source permissions), and the shell fallback must not run.
-    calls = []
-
-    class Channel:
-        supports_remote_copy = True
-
-        async def stat(self, path):
-            raise SFTPNoSuchFile("destination does not exist")
-
-        async def realpath(self, path):
-            return "/real" + path
-
-        async def copy(self, lpath, rpath, **kwargs):
-            calls.append((lpath, rpath, kwargs))
-
-    async def no_shell(*args, **kwargs):
-        raise AssertionError("shell fallback must not run")
-
-    monkeypatch.setattr(fs, "_supports_remote_copy", None)
-    monkeypatch.setattr(fs, "_pool", _FakeChannelPool(Channel()))
-    monkeypatch.setattr(fs, "_execute", no_shell)
-
-    expected = {
-        "preserve": True,
-        "follow_symlinks": True,
-        "remote_only": True,
-    }
-    fs.cp_file("/src", "/dst")
-    assert calls == [("/src", "/dst", expected)]
-
-    # The probed capability is cached and reused.
-    fs.cp_file("/src2", "/dst2")
-    assert calls[-1] == ("/src2", "/dst2", expected)
+@pytest.fixture
+def copydata_fs(asyncssh_server):
+    host, port = asyncssh_server
+    yield SSHFileSystem(host=host, port=port, username="user")
 
 
-def test_cp_file_same_file(fs, monkeypatch):
-    # Aliased source and destination (same path or a symlink to the
-    # source) must fail before any data is touched: asyncssh's copy
-    # opens the destination with truncation and would destroy the
-    # source, while shell cp refuses the copy.
-    class Channel:
-        supports_remote_copy = True
+def test_cp_file_copy_data(copydata_fs, tmp_path):
+    fs = copydata_fs
+    src = tmp_path / "src"
+    src.write_bytes(b"payload")
+    src.chmod(0o640)
 
-        async def stat(self, path):
-            return SFTPAttrs(permissions=0o100644)
+    dst = tmp_path / "dst"
+    fs.cp_file(str(src), str(dst))
+    # the copy-data path was actually taken, not the shell fallback
+    assert fs._supports_remote_copy is True
+    assert dst.read_bytes() == b"payload"
+    # a new destination gets the source's mode
+    assert (dst.stat().st_mode & 0o7777) == 0o640
 
-        async def realpath(self, path):
-            return "/real/same"
+    # an existing destination keeps its own mode, like cp
+    dst.chmod(0o600)
+    fs.cp_file(str(src), str(dst))
+    assert dst.read_bytes() == b"payload"
+    assert (dst.stat().st_mode & 0o7777) == 0o600
 
-        async def copy(self, *args, **kwargs):
-            raise AssertionError("copy must not run on aliased paths")
 
-    async def no_shell(*args, **kwargs):
-        raise AssertionError("shell fallback must not run")
-
-    monkeypatch.setattr(fs, "_supports_remote_copy", None)
-    monkeypatch.setattr(fs, "_pool", _FakeChannelPool(Channel()))
-    monkeypatch.setattr(fs, "_execute", no_shell)
+def test_cp_file_copy_data_aliases(copydata_fs, tmp_path):
+    fs = copydata_fs
+    src = tmp_path / "src"
+    src.write_bytes(b"payload")
 
     with pytest.raises(shutil.SameFileError):
-        fs.cp_file("/a", "/link-to-a")
+        fs.cp_file(str(src), str(src))
+
+    # bytes and str spellings of the same path are still aliases
+    with pytest.raises(shutil.SameFileError):
+        fs.cp_file(str(src).encode(), str(src))
+
+    link = tmp_path / "link"
+    link.symlink_to(src)
+    with pytest.raises(shutil.SameFileError):
+        fs.cp_file(str(src), str(link))
+
+    # hardlink aliases cannot be detected over SFTP; the copy must
+    # still never destroy the source
+    hard = tmp_path / "hard"
+    os.link(src, hard)
+    fs.cp_file(str(src), str(hard))
+    assert src.read_bytes() == b"payload"
+    assert hard.read_bytes() == b"payload"
 
 
-def test_cp_file_directory_destination(fs, monkeypatch):
-    # A directory destination means "copy into" with cp's resolution
-    # rules (and its own same-file protections, e.g.
-    # cp_file("/dir/file", "/dir")), so it must take the shell path
-    # even when copy-data is available.
-    calls = []
+def test_cp_file_copy_data_directory_destination(copydata_fs, tmp_path):
+    fs = copydata_fs
+    src = tmp_path / "src"
+    src.write_bytes(b"payload")
 
+    directory = tmp_path / "directory"
+    directory.mkdir()
+    fs.cp_file(str(src), str(directory))
+    assert (directory / "src").read_bytes() == b"payload"
+
+    # "copy into" resolving to the source itself is an alias
+    with pytest.raises(shutil.SameFileError):
+        fs.cp_file(str(directory / "src"), str(directory))
+    assert (directory / "src").read_bytes() == b"payload"
+
+
+def test_mv_fallback_keeps_source_on_copy_failure(fs, monkeypatch):
+    # When posix_rename is unsupported and the copy fails, the source
+    # must survive: it may only be removed after a successful copy.
     class Channel:
-        supports_remote_copy = True
+        async def posix_rename(self, lpath, rpath):
+            raise SFTPOpUnsupported("posix-rename not supported")
 
-        async def stat(self, path):
-            return SFTPAttrs(permissions=0o040755)
+    removed = []
 
-        async def realpath(self, path):
-            raise AssertionError("realpath not needed for dir targets")
+    async def failing_cp(*args, **kwargs):
+        raise OSError("copy failed")
 
-        async def copy(self, *args, **kwargs):
-            raise AssertionError("copy must not run for dir targets")
+    async def record_rm(path, **kwargs):
+        removed.append(path)
 
-    async def record_shell(cmd, **kwargs):
-        calls.append(cmd)
-
-    monkeypatch.setattr(fs, "_supports_remote_copy", None)
     monkeypatch.setattr(fs, "_pool", _FakeChannelPool(Channel()))
-    monkeypatch.setattr(fs, "_execute", record_shell)
+    monkeypatch.setattr(fs, "_cp_file", failing_cp)
+    monkeypatch.setattr(fs, "_rm_file", record_rm)
 
-    fs.cp_file("/dir/file", "/dir")
-    assert calls == ["cp /dir/file /dir"]
+    with pytest.raises(OSError):
+        fs.mv("/src", "/dst")
+    assert removed == []
+
+    async def ok_cp(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr(fs, "_cp_file", ok_cp)
+    fs.mv("/src", "/dst")
+    assert removed == ["/src"]
 
 
 @pytest.mark.parametrize("legacy_asyncssh", [False, True])

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -235,43 +235,60 @@ def test_cp_file_remote_copy(fs, monkeypatch):
     # A channel advertising copy-data must be used with remote_only=True
     # (otherwise asyncssh silently copies through the client) and the
     # shell fallback must not run.
-    calls = {}
+    calls = []
 
     class Channel:
         supports_remote_copy = True
 
         async def copy(self, lpath, rpath, remote_only=False):
-            calls["copy"] = (lpath, rpath, remote_only)
+            calls.append((lpath, rpath, remote_only))
 
     async def no_shell(*args, **kwargs):
         raise AssertionError("shell fallback must not run")
 
+    monkeypatch.setattr(fs, "_supports_remote_copy", None)
     monkeypatch.setattr(fs, "_pool", _FakeChannelPool(Channel()))
     monkeypatch.setattr(fs, "_execute", no_shell)
 
     fs.cp_file("/src", "/dst")
-    assert calls["copy"] == ("/src", "/dst", True)
+    assert calls == [("/src", "/dst", True)]
+
+    # The probed capability is cached and reused.
+    fs.cp_file("/src2", "/dst2")
+    assert calls[-1] == ("/src2", "/dst2", True)
 
 
-def test_cp_file_shell_fallback(fs, monkeypatch):
-    # Without copy-data support (or on asyncssh < 2.19, where the
-    # attribute does not exist), the shell cp path is used.
-    calls = {}
+@pytest.mark.parametrize("legacy_asyncssh", [False, True])
+def test_cp_file_shell_fallback(fs, monkeypatch, legacy_asyncssh):
+    # Channels without copy-data support -- and asyncssh < 2.19
+    # channels, which lack the supports_remote_copy attribute entirely
+    # -- must use the shell cp path, and only the first call may touch
+    # the channel pool (the probed capability is cached).
+    calls = []
+    pool_uses = []
 
     class Channel:
-        supports_remote_copy = False
-
         async def copy(self, *args, **kwargs):
             raise AssertionError("copy-data must not be attempted")
 
-    async def record_shell(cmd, **kwargs):
-        calls["cmd"] = cmd
+    if not legacy_asyncssh:
+        Channel.supports_remote_copy = False
 
-    monkeypatch.setattr(fs, "_pool", _FakeChannelPool(Channel()))
+    async def record_shell(cmd, **kwargs):
+        calls.append(cmd)
+
+    pool = _FakeChannelPool(Channel())
+    _orig_get = pool.get
+    pool.get = lambda: pool_uses.append(1) or _orig_get()
+
+    monkeypatch.setattr(fs, "_supports_remote_copy", None)
+    monkeypatch.setattr(fs, "_pool", pool)
     monkeypatch.setattr(fs, "_execute", record_shell)
 
     fs.cp_file("/src", "/dst")
-    assert calls["cmd"] == "cp /src /dst"
+    fs.cp_file("/src2", "/dst2")
+    assert calls == ["cp /src /dst", "cp /src2 /dst2"]
+    assert len(pool_uses) == 1
 
 
 def test_rm(fs, remote_dir):

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -307,6 +307,65 @@ def test_cp_file_copy_data_creates(copydata_fs, copydata_dir):
 
 
 @requires_copy_data
+def test_cp_file_copy_data_ignores_reported_size(zero_size_server):
+    # Sources whose stat lies about the size (procfs, sysfs) must be
+    # copied whole: the copy runs to the source's real end of file and
+    # never sizes the destination from a stat snapshot.
+    host, port, root = zero_size_server
+    fs = SSHFileSystem(
+        host=host, port=port, username="user", client_keys=[USERS["user"]]
+    )
+    try:
+        (root / "src").write_bytes(b"payload" * 1000)
+        assert fs.info("/src")["size"] == 0
+
+        fs.cp_file("/src", "/dst")
+        assert fs._supports_remote_copy is True
+        assert (root / "dst").read_bytes() == b"payload" * 1000
+    finally:
+        with suppress(Exception):
+            sync(fs.loop, fs._stack.aclose, timeout=5)
+
+
+def test_remote_copy_keeps_mode_zero(fs, monkeypatch):
+    # A mode of 0 is a valid mode, not a missing one: it must be
+    # requested as-is instead of falling back to the server's default
+    # (SFTP v4+ reports it as permissions == 0, since the file type
+    # lives in a separate field).
+    opened = []
+
+    class _File:
+        async def stat(self):
+            return SFTPAttrs(permissions=0)
+
+        async def close(self):
+            pass
+
+    class Channel:
+        supports_remote_copy = True
+
+        def encode(self, path):
+            return path.encode() if isinstance(path, str) else path
+
+        async def isdir(self, path):
+            return False
+
+        async def open(self, path, *args, **kwargs):
+            opened.append((path, args))
+            return _File()
+
+        async def remote_copy(self, src, dst):
+            pass
+
+    monkeypatch.setattr(fs, "_supports_remote_copy", True)
+    monkeypatch.setattr(fs, "_pool", _FakeChannelPool(Channel()))
+
+    fs.cp_file("/src", "/dst")
+    _dst_path, dst_args = opened[-1]
+    assert dst_args[1].permissions == 0
+
+
+@requires_copy_data
 def test_cp_file_copy_data_existing_destinations(copydata_fs, copydata_dir):
     # The extension path only creates destinations. Anything existing
     # -- including every alias of the source -- is left to the shell

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -211,6 +211,66 @@ def test_copy(fs, remote_dir):
     assert strip_keys(initial_info) == strip_keys(secondary_info)
 
 
+class _FakeChannelPool:
+    def __init__(self, channel):
+        self.channel = channel
+
+    def get(self):
+        pool = self
+
+        class _Ctx:
+            async def __aenter__(self):
+                return pool.channel
+
+            async def __aexit__(self, *exc):
+                return False
+
+        return _Ctx()
+
+
+def test_cp_file_remote_copy(fs, monkeypatch):
+    # A channel advertising copy-data must be used with remote_only=True
+    # (otherwise asyncssh silently copies through the client) and the
+    # shell fallback must not run.
+    calls = {}
+
+    class Channel:
+        supports_remote_copy = True
+
+        async def copy(self, lpath, rpath, remote_only=False):
+            calls["copy"] = (lpath, rpath, remote_only)
+
+    async def no_shell(*args, **kwargs):
+        raise AssertionError("shell fallback must not run")
+
+    monkeypatch.setattr(fs, "_pool", _FakeChannelPool(Channel()))
+    monkeypatch.setattr(fs, "_execute", no_shell)
+
+    fs.cp_file("/src", "/dst")
+    assert calls["copy"] == ("/src", "/dst", True)
+
+
+def test_cp_file_shell_fallback(fs, monkeypatch):
+    # Without copy-data support (or on asyncssh < 2.19, where the
+    # attribute does not exist), the shell cp path is used.
+    calls = {}
+
+    class Channel:
+        supports_remote_copy = False
+
+        async def copy(self, *args, **kwargs):
+            raise AssertionError("copy-data must not be attempted")
+
+    async def record_shell(cmd, **kwargs):
+        calls["cmd"] = cmd
+
+    monkeypatch.setattr(fs, "_pool", _FakeChannelPool(Channel()))
+    monkeypatch.setattr(fs, "_execute", record_shell)
+
+    fs.cp_file("/src", "/dst")
+    assert calls["cmd"] == "cp /src /dst"
+
+
 def test_rm(fs, remote_dir):
     fs.touch(remote_dir + "/a.txt")
     fs.rm(remote_dir + "/a.txt")

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 
 import fsspec
 import pytest
-from asyncssh.sftp import SFTPAttrs, SFTPFailure
+from asyncssh.sftp import SFTPAttrs, SFTPFailure, SFTPNoSuchFile
 from importlib_metadata import entry_points
 
 from sshfs import SSHFileSystem
@@ -242,6 +242,9 @@ def test_cp_file_remote_copy(fs, monkeypatch):
     class Channel:
         supports_remote_copy = True
 
+        async def stat(self, path):
+            raise SFTPNoSuchFile("destination does not exist")
+
         async def realpath(self, path):
             return "/real" + path
 
@@ -276,6 +279,9 @@ def test_cp_file_same_file(fs, monkeypatch):
     class Channel:
         supports_remote_copy = True
 
+        async def stat(self, path):
+            return SFTPAttrs(permissions=0o100644)
+
         async def realpath(self, path):
             return "/real/same"
 
@@ -291,6 +297,36 @@ def test_cp_file_same_file(fs, monkeypatch):
 
     with pytest.raises(shutil.SameFileError):
         fs.cp_file("/a", "/link-to-a")
+
+
+def test_cp_file_directory_destination(fs, monkeypatch):
+    # A directory destination means "copy into" with cp's resolution
+    # rules (and its own same-file protections, e.g.
+    # cp_file("/dir/file", "/dir")), so it must take the shell path
+    # even when copy-data is available.
+    calls = []
+
+    class Channel:
+        supports_remote_copy = True
+
+        async def stat(self, path):
+            return SFTPAttrs(permissions=0o040755)
+
+        async def realpath(self, path):
+            raise AssertionError("realpath not needed for dir targets")
+
+        async def copy(self, *args, **kwargs):
+            raise AssertionError("copy must not run for dir targets")
+
+    async def record_shell(cmd, **kwargs):
+        calls.append(cmd)
+
+    monkeypatch.setattr(fs, "_supports_remote_copy", None)
+    monkeypatch.setattr(fs, "_pool", _FakeChannelPool(Channel()))
+    monkeypatch.setattr(fs, "_execute", record_shell)
+
+    fs.cp_file("/dir/file", "/dir")
+    assert calls == ["cp /dir/file /dir"]
 
 
 @pytest.mark.parametrize("legacy_asyncssh", [False, True])

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -6,13 +6,15 @@ import shutil
 import tempfile
 import warnings
 from concurrent import futures
+from contextlib import suppress
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 
 import fsspec
 import pytest
-from asyncssh.sftp import SFTPAttrs, SFTPFailure, SFTPOpUnsupported
+from asyncssh.sftp import SFTPAttrs, SFTPError, SFTPFailure, SFTPOpUnsupported
+from fsspec.asyn import sync
 from importlib_metadata import entry_points
 
 from sshfs import SSHFileSystem
@@ -234,73 +236,121 @@ class _FakeChannelPool:
         return _Ctx()
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def copydata_fs(asyncssh_server):
-    host, port = asyncssh_server
-    yield SSHFileSystem(host=host, port=port, username="user")
+    host, port, _root = asyncssh_server
+    fs = SSHFileSystem(
+        host=host,
+        port=port,
+        username="user",
+        client_keys=[USERS["user"]],
+    )
+    yield fs
+    # Close the connection so the server fixture can shut its loop
+    # down without cancelling live connection tasks.
+    with suppress(Exception):
+        sync(fs.loop, fs._stack.aclose, timeout=5)
 
 
-def test_cp_file_copy_data(copydata_fs, tmp_path):
+@pytest.fixture
+def copydata_dir(asyncssh_server, request):
+    _host, _port, root = asyncssh_server
+    local = root / request.node.name
+    local.mkdir()
+    # the server is chrooted to `root`, so `local` is served as this
+    # remote path
+    yield local, "/" + local.name
+
+
+def test_cp_file_copy_data(copydata_fs, copydata_dir):
     fs = copydata_fs
-    src = tmp_path / "src"
-    src.write_bytes(b"payload")
-    src.chmod(0o640)
+    local, remote = copydata_dir
+    (local / "src").write_bytes(b"payload")
+    (local / "src").chmod(0o666)
 
-    dst = tmp_path / "dst"
-    fs.cp_file(str(src), str(dst))
+    umask = os.umask(0)
+    os.umask(umask)
+
+    fs.cp_file(remote + "/src", remote + "/dst")
     # the copy-data path was actually taken, not the shell fallback
     assert fs._supports_remote_copy is True
-    assert dst.read_bytes() == b"payload"
-    # a new destination gets the source's mode
-    assert (dst.stat().st_mode & 0o7777) == 0o640
+    assert (local / "dst").read_bytes() == b"payload"
+    # a new file gets the source's mode filtered by the server's
+    # umask, like cp
+    assert ((local / "dst").stat().st_mode & 0o7777) == 0o666 & ~umask
 
-    # an existing destination keeps its own mode, like cp
-    dst.chmod(0o600)
-    fs.cp_file(str(src), str(dst))
-    assert dst.read_bytes() == b"payload"
-    assert (dst.stat().st_mode & 0o7777) == 0o600
+    # an existing destination keeps its inode: its own mode survives
+    # and hardlink peers see the update, like cp writing through the
+    # file
+    (local / "dst").chmod(0o600)
+    os.link(local / "dst", local / "peer")
+    (local / "src").write_bytes(b"new payload")
+    fs.cp_file(remote + "/src", remote + "/dst")
+    assert (local / "dst").read_bytes() == b"new payload"
+    assert ((local / "dst").stat().st_mode & 0o7777) == 0o600
+    assert (local / "peer").read_bytes() == b"new payload"
 
 
-def test_cp_file_copy_data_aliases(copydata_fs, tmp_path):
+def test_cp_file_copy_data_aliases(copydata_fs, copydata_dir):
     fs = copydata_fs
-    src = tmp_path / "src"
+    local, remote = copydata_dir
+    src = local / "src"
     src.write_bytes(b"payload")
 
     with pytest.raises(shutil.SameFileError):
-        fs.cp_file(str(src), str(src))
+        fs.cp_file(remote + "/src", remote + "/src")
 
     # bytes and str spellings of the same path are still aliases
     with pytest.raises(shutil.SameFileError):
-        fs.cp_file(str(src).encode(), str(src))
+        fs.cp_file((remote + "/src").encode(), remote + "/src")
 
-    link = tmp_path / "link"
-    link.symlink_to(src)
+    (local / "link").symlink_to("src")
     with pytest.raises(shutil.SameFileError):
-        fs.cp_file(str(src), str(link))
+        fs.cp_file(remote + "/src", remote + "/link")
 
-    # hardlink aliases cannot be detected over SFTP; the copy must
-    # still never destroy the source
-    hard = tmp_path / "hard"
-    os.link(src, hard)
-    fs.cp_file(str(src), str(hard))
+    # hardlink aliases cannot be detected over SFTP: the write-through
+    # copy puts the bytes over themselves and must leave the file,
+    # its content and the link intact
+    os.link(src, local / "hard")
+    fs.cp_file(remote + "/src", remote + "/hard")
     assert src.read_bytes() == b"payload"
-    assert hard.read_bytes() == b"payload"
+    assert (local / "hard").stat().st_ino == src.stat().st_ino
 
 
-def test_cp_file_copy_data_directory_destination(copydata_fs, tmp_path):
+def test_cp_file_copy_data_directory_destination(copydata_fs, copydata_dir):
     fs = copydata_fs
-    src = tmp_path / "src"
-    src.write_bytes(b"payload")
+    local, remote = copydata_dir
+    (local / "src").write_bytes(b"payload")
+    (local / "d").mkdir()
 
-    directory = tmp_path / "directory"
-    directory.mkdir()
-    fs.cp_file(str(src), str(directory))
-    assert (directory / "src").read_bytes() == b"payload"
+    fs.cp_file(remote + "/src", remote + "/d")
+    assert (local / "d" / "src").read_bytes() == b"payload"
 
     # "copy into" resolving to the source itself is an alias
     with pytest.raises(shutil.SameFileError):
-        fs.cp_file(str(directory / "src"), str(directory))
-    assert (directory / "src").read_bytes() == b"payload"
+        fs.cp_file(remote + "/d/src", remote + "/d")
+    assert (local / "d" / "src").read_bytes() == b"payload"
+
+
+def test_cp_file_copy_data_destination_errors(copydata_fs, copydata_dir):
+    fs = copydata_fs
+    local, remote = copydata_dir
+    (local / "src").write_bytes(b"payload")
+
+    # a read-only destination is refused at open, like cp, and stays
+    # untouched
+    ro = local / "ro"
+    ro.write_bytes(b"old")
+    ro.chmod(0o444)
+    with pytest.raises(PermissionError):
+        fs.cp_file(remote + "/src", remote + "/ro")
+    assert ro.read_bytes() == b"old"
+
+    # a trailing slash on a file destination is not a directory (the
+    # server rejects it; like mkdir, the SFTP error is passed through)
+    with pytest.raises((OSError, SFTPError)):
+        fs.cp_file(remote + "/src", remote + "/ro/")
+    assert ro.read_bytes() == b"old"
 
 
 def test_mv_fallback_keeps_source_on_copy_failure(fs, monkeypatch):

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -1,6 +1,7 @@
 import hashlib
 import posixpath
 import secrets
+import shutil
 import tempfile
 import warnings
 from concurrent import futures
@@ -233,15 +234,19 @@ class _FakeChannelPool:
 
 def test_cp_file_remote_copy(fs, monkeypatch):
     # A channel advertising copy-data must be used with remote_only=True
-    # (otherwise asyncssh silently copies through the client) and the
-    # shell fallback must not run.
+    # (otherwise asyncssh silently copies through the client), matching
+    # the shell fallback's semantics (content of the link target,
+    # source permissions), and the shell fallback must not run.
     calls = []
 
     class Channel:
         supports_remote_copy = True
 
-        async def copy(self, lpath, rpath, remote_only=False):
-            calls.append((lpath, rpath, remote_only))
+        async def realpath(self, path):
+            return "/real" + path
+
+        async def copy(self, lpath, rpath, **kwargs):
+            calls.append((lpath, rpath, kwargs))
 
     async def no_shell(*args, **kwargs):
         raise AssertionError("shell fallback must not run")
@@ -250,12 +255,42 @@ def test_cp_file_remote_copy(fs, monkeypatch):
     monkeypatch.setattr(fs, "_pool", _FakeChannelPool(Channel()))
     monkeypatch.setattr(fs, "_execute", no_shell)
 
+    expected = {
+        "preserve": True,
+        "follow_symlinks": True,
+        "remote_only": True,
+    }
     fs.cp_file("/src", "/dst")
-    assert calls == [("/src", "/dst", True)]
+    assert calls == [("/src", "/dst", expected)]
 
     # The probed capability is cached and reused.
     fs.cp_file("/src2", "/dst2")
-    assert calls[-1] == ("/src2", "/dst2", True)
+    assert calls[-1] == ("/src2", "/dst2", expected)
+
+
+def test_cp_file_same_file(fs, monkeypatch):
+    # Aliased source and destination (same path or a symlink to the
+    # source) must fail before any data is touched: asyncssh's copy
+    # opens the destination with truncation and would destroy the
+    # source, while shell cp refuses the copy.
+    class Channel:
+        supports_remote_copy = True
+
+        async def realpath(self, path):
+            return "/real/same"
+
+        async def copy(self, *args, **kwargs):
+            raise AssertionError("copy must not run on aliased paths")
+
+    async def no_shell(*args, **kwargs):
+        raise AssertionError("shell fallback must not run")
+
+    monkeypatch.setattr(fs, "_supports_remote_copy", None)
+    monkeypatch.setattr(fs, "_pool", _FakeChannelPool(Channel()))
+    monkeypatch.setattr(fs, "_execute", no_shell)
+
+    with pytest.raises(shutil.SameFileError):
+        fs.cp_file("/a", "/link-to-a")
 
 
 @pytest.mark.parametrize("legacy_asyncssh", [False, True])

--- a/tests/test_sshfs.py
+++ b/tests/test_sshfs.py
@@ -199,7 +199,9 @@ def test_move(fs, remote_dir):
 
 
 def test_copy(fs, remote_dir):
-    fs.touch(remote_dir + "/a.txt")
+    data = b"data to copy"
+    with fs.open(remote_dir + "/a.txt", "wb") as stream:
+        stream.write(data)
     initial_info = fs.info(remote_dir + "/a.txt")
 
     fs.copy(remote_dir + "/a.txt", remote_dir + "/b.txt")
@@ -207,6 +209,7 @@ def test_copy(fs, remote_dir):
 
     assert fs.exists(remote_dir + "/a.txt")
     assert fs.exists(remote_dir + "/b.txt")
+    assert fs.cat_file(remote_dir + "/b.txt") == data
 
     assert strip_keys(initial_info) == strip_keys(secondary_info)
 


### PR DESCRIPTION
## Problem
`cp_file` (and the `move` fallback) shells out to `cp` over an SSH exec channel. SFTP-only servers that deny exec (chrooted `internal-sftp`, transfer appliances) can't copy at all, and the remote must have a POSIX shell with `cp`.

## Change
When the channel advertises the `copy-data` extension (`supports_remote_copy`, asyncssh >= 2.19 talking to e.g. OpenSSH >= 9.0) **and the destination does not exist**, the file is copied server-side: the source is opened, the destination is created with `FXF_WRITE|FXF_CREAT|FXF_EXCL` (mode = the source's mode without special bits, filtered by the server's umask; a directory destination resolves to `dir/basename(src)` first), and a single copy-data request copies until the source's end of file. No shell, no data through the client, and no size assumptions — sources whose stat lies (procfs-style) copy correctly. A failed or interrupted copy may leave a partial destination, exactly like an interrupted `cp`; it is deliberately never unlinked, since over SFTP a pathname cannot be re-verified to still name the file this client created (an unrelated file could race onto the same name).

**Everything else goes to the shell `cp` fallback, byte-for-byte as before this PR**: existing destinations — which include every alias of the source (same path, symlink, or hardlink, the latter undetectable over SFTP) — dangling destination symlinks (`FXF_EXCL` refuses to create through them), missing parents. In-place overwrite over SFTP is deliberately **not** implemented: a stale pre-copy size corrupts changing or stat-lying sources, a post-copy truncate can be denied by fsetstat policy after the destination was already modified, a pre-copy truncate destroys hardlink-aliased sources, and replacing the directory entry loses the inode. `cp` owns those semantics.

Guards and fixes along the way:
- Capability probed once per connection and cached; asyncssh <= 2.18 (no client-side copy-data) stays on the shell path via `getattr` — no version-pin change.
- copy-data **advertised but denied** falls back to the shell for that copy. Only an *unsupported* request (a property of the server) disables the extension for the connection; a denial can depend on the paths involved, so it is never cached.
- Individually denied `fstat` (OpenSSH `-P fstat`) is tolerated and **fails closed**: an unknown source mode creates the destination `0600` rather than the server's world-readable default. A known mode is copied exactly.
- **`move` no longer copies and deletes.** It tries posix-rename, then the standard SFTP rename, then the remote `mv`. A copy only proves that bytes reached an open handle, not that the destination path still names it, so deleting the source afterwards could destroy the only remaining copy of the data. On a server without shell access a move that neither rename can perform now fails with the source untouched. A denied rename propagates instead of being downgraded to something with different semantics.
- **`info()["type"]`, `isdir()` and `isfile()` are fixed for SFTP v4+** servers, which report the file type in its own field rather than in the permission bits (pre-existing bug, surfaced by the new v4 fixture; can be split out if you prefer).
- `SFTPPermissionDenied` is now mapped to `PermissionError` (previously leaked the asyncssh exception through the public API).
- The `move` fallback removes the source **only after a successful copy** (previously a `finally` deleted it even when the copy failed).
- The shell fallback accepts bytes paths, decoded as UTF-8 (non-UTF-8 byte paths cannot ride a shell command and only work on SFTP-channel operations), and passes `--` so a path starting with a dash is not parsed as a `cp` option.

Known divergences and operational notes on the copy-data path:
- Sparse sources are materialized densely (OpenSSH's copy-data has no hole detection — mind disk headroom for huge sparse files); macOS resource forks/xattrs are not copied.
- A failed or interrupted copy leaves a partial destination that is deliberately not unlinked. On a server that also offers a shell this only means `cp` overwrites it on the next attempt, but **on an SFTP-only server a retry hits the existing-destination path and fails until the partial file is removed** — automatic retries cannot clear it themselves.

## Tests
asyncssh-based server fixture (implements copy-data natively, unlike paramiko-based mockssh): chrooted to a fresh directory, key-authenticated, cleanly shut down (no leaked tasks). Functional coverage of the create-only contract: content and umask-filtered mode, copy-into-directory, existing/alias destinations fail untouched when no shell is available, dangling destination symlinks refused. Skipped on asyncssh < 2.19; per-test directories and names are rerun-safe; the suite runs once per SFTP protocol generation with the **server** offering v3 or v4 (v4+ separates file type from permissions) and a test asserting the negotiated version, so that coverage claim cannot silently regress. Policy denial is unit-tested (falls back for that copy, extension stays enabled) and an unsupported request separately (extension disabled); gating/caching and the move fallback's source preservation are pinned.